### PR TITLE
feat: STORY-0001.1.2 Real Configuration Management

### DIFF
--- a/.claude/commands/review-pr-comments.md
+++ b/.claude/commands/review-pr-comments.md
@@ -1,0 +1,361 @@
+---
+description: Address all GitHub PR review comments with automated fix/test/commit/respond workflow
+allowed-tools: "*"
+---
+
+# Automated PR Review Comment Resolution
+
+You are tasked with systematically addressing ALL unresolved review comments on the current branch's GitHub Pull Request. Follow this workflow for EACH comment:
+
+## Overall Workflow
+
+For each unresolved review comment:
+
+1. **Review Comment & Determine Response**
+   - Fetch comment content and file context
+   - Analyze the concern/suggestion
+   - Determine if code changes are needed or if an explanation suffices
+
+2. **Get User Approval** ⚠️ **REQUIRED**
+   - Present your analysis and proposed action to the user
+   - Wait for explicit approval before proceeding
+   - Iterate on the plan if user requests modifications
+
+3. **Update Code (if approved)**
+   - Make necessary code changes to address the comment
+   - Follow project conventions from CLAUDE.md
+
+4. **Run Quality Gates (iterate until all pass)**
+   - Run: `uv run poe fix` to auto-fix formatting/linting
+   - Run: `uv run poe quality` for all checks (ruff, mypy, pytest)
+   - If any fail, fix issues and repeat until all pass
+
+5. **Commit and Push**
+   - Create commit with format: `fix(STORY-ID): Address review comment #COMMENT_ID - brief description`
+   - Include commit body explaining the change and why
+   - Add standard footer: 🤖 Generated with [Claude Code](https://claude.com/claude-code) + Co-Authored-By
+   - Push to remote
+
+6. **Watch CI (iterate until green)**
+   - Get latest CI run: `gh run list --limit 1`
+   - Watch it: `gh run watch RUN_ID`
+   - If CI fails, analyze failures, fix, and repeat from step 4
+   - Continue until CI passes completely
+
+7. **Reply to and Resolve Comment**
+   - Use the poe task to reply and resolve in one command:
+     ```bash
+     PR_NUMBER=N COMMENT_ID=COMMENT_ID REPLY_BODY="**Fixed** - Description.
+
+     **Changes:**
+     - Bullet point of changes
+
+     **Commit:** commit-hash" uv run poe pr-address-comment
+     ```
+   - The poe task automatically adds "On behalf of @username" footer
+
+## Step-by-Step Instructions
+
+### Step 1: Get Current Branch and PR Info
+
+```bash
+# Get current branch
+BRANCH=$(git branch --show-current)
+
+# Get PR number for this branch
+gh pr view --json number,title,url --jq '{number, title, url}'
+```
+
+Store the PR number as you'll need it for comment operations.
+
+### Step 2: Fetch All Unresolved Review Comments
+
+```bash
+# Get all review comments (including thread info)
+gh api graphql -f query='
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 50) {
+        nodes {
+          id
+          isResolved
+          path
+          line
+          comments(first: 10) {
+            nodes {
+              databaseId
+              author { login }
+              body
+              path
+              position
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+}' -f owner=OWNER -f repo=REPO -F number=PR_NUMBER
+```
+
+Parse this to identify unresolved threads (isResolved: false).
+
+### Step 3: Create Todo List
+
+Use TodoWrite to create a task for each unresolved comment:
+- Todo content: "Address comment #COMMENT_ID from AUTHOR: [first 50 chars of comment]"
+- Todo activeForm: "Addressing comment #COMMENT_ID"
+- Status: pending
+
+### Step 4: Process Each Comment
+
+For each todo item (comment):
+
+#### 4.1 Display Comment Context
+- Show the comment ID, author, file, line number
+- Show the comment body in full
+- Read the file and show context around the commented line
+
+#### 4.2 Analyze & Determine Fix
+- Explain what the comment is asking for
+- Determine if code changes are needed
+- If explanation only: prepare explanation text
+- If fix needed: describe what changes will be made
+
+#### 4.3 Get User Approval for Proposed Action ⚠️ **MANDATORY STOP POINT**
+
+**STOP and WAIT for user approval before proceeding:**
+
+Present to the user:
+1. **Comment ID**: #COMMENT_ID
+2. **Author**: @AUTHOR
+3. **Comment Content**: [Full comment text]
+4. **File**: path/to/file.py (line X)
+5. **Current Code Context**: [Show relevant code]
+6. **Analysis**: [Your understanding of what the comment is asking for]
+7. **Proposed Action**:
+   - If code change: Describe specifically what you will change and why
+   - If explanation only: Show the explanation you will provide
+   - If other: Describe what you will do
+
+**Ask the user**: "Do you approve this approach to address comment #COMMENT_ID? (yes/no/modify)"
+
+**Response Handling:**
+- **yes**: Proceed to step 4.4
+- **no**: Ask "What approach would you prefer?" Then revise the plan and re-present for approval
+- **modify**: Get their guidance, revise the plan, and re-present for approval
+
+**CRITICAL**: Do not make any code changes, commits, or comment replies until the user explicitly approves your proposed action with "yes".
+
+#### 4.4 Make Code Changes (if approved and needed)
+- Use Edit tool to make necessary changes
+- Follow project conventions and coding standards
+- Make minimal, focused changes
+
+#### 4.5 Run Quality Gates
+
+Use the project's poe tasks for quality gates:
+
+```bash
+# Auto-fix formatting and linting issues
+uv run poe fix
+
+# Run all quality checks (ruff, mypy, pytest)
+uv run poe quality
+```
+
+If `poe quality` fails:
+- Analyze the error output
+- Make necessary fixes
+- Run `uv run poe fix` again if needed
+- Re-run `uv run poe quality`
+- Repeat until all checks pass
+
+Continue until ALL quality gates pass (exit code 0 from `poe quality`).
+
+#### 4.6 Commit Changes
+
+Get current story/branch ID for scope:
+```bash
+STORY_ID=$(git branch --show-current)
+```
+
+Create commit:
+```bash
+git add .
+
+git commit -m "$(cat <<'EOF'
+fix(${STORY_ID}): Address review comment #${COMMENT_ID} - brief description
+
+Detailed explanation of what was changed and why this addresses
+the review comment.
+
+Addresses: Comment #${COMMENT_ID} from ${AUTHOR}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+Push:
+```bash
+git push
+```
+
+#### 4.7 Monitor CI
+
+```bash
+# Get the latest workflow run
+RUN_ID=$(gh run list --limit 1 --json databaseId --jq '.[0].databaseId')
+
+# Watch it until completion
+gh run watch $RUN_ID
+```
+
+Check the exit code:
+- Exit 0: CI passed ✅ - continue to reply
+- Non-zero: CI failed ❌ - analyze logs, fix issues, repeat from 4.5
+
+To view failures:
+```bash
+gh run view $RUN_ID --log-failed
+```
+
+#### 4.8 Reply and Resolve Comment
+
+Once CI is green and all quality gates pass:
+
+```bash
+# Get the commit hash
+COMMIT_HASH=$(git log -1 --format=%h)
+
+# Prepare reply body
+REPLY_BODY="**Fixed** - [Description of what was changed]
+
+**Changes:**
+- [Bullet point describing the change]
+- [Another bullet if needed]
+
+**Commit:** ${COMMIT_HASH}"
+
+# Use poe task to reply and resolve
+PR_NUMBER=${PR_NUMBER} COMMENT_ID=${COMMENT_ID} REPLY_BODY="${REPLY_BODY}" uv run poe pr-address-comment
+```
+
+The poe task will:
+1. Find the thread ID from the comment ID
+2. Add your reply to the thread
+3. Resolve the thread
+4. Automatically add "On behalf of @username" footer
+
+#### 4.9 Mark Todo Complete
+
+Update the todo item for this comment to status "completed".
+
+### Step 5: Repeat for All Comments
+
+Continue through all unresolved comments in the todo list until all are marked completed.
+
+### Step 6: Final Verification
+
+After all comments are addressed:
+
+```bash
+# Verify no unresolved threads remain
+gh pr view --json reviewThreads --jq '.reviewThreads[] | select(.isResolved == false)'
+```
+
+Should return empty. If any remain, investigate and address them.
+
+## Important Notes
+
+1. **User Approval Required**: ALWAYS wait for explicit user approval before making any code changes or posting any comment replies. This is a mandatory stop point in the workflow.
+
+2. **Use Poe Tasks**: The project uses poe tasks for quality gates. Always use `uv run poe fix` and `uv run poe quality` rather than running tools individually.
+
+3. **Story ID**: Use the current branch name as the scope in commit messages (e.g., STORY-0001.1.2)
+
+4. **Quality Gates**: NEVER skip quality gates. All must pass before committing.
+
+5. **CI Monitoring**: ALWAYS wait for CI to go green before replying to comments. Don't create a reply saying "fixed" if CI is failing.
+
+6. **Commit Messages**: Follow the project's conventional commit format strictly.
+
+7. **One Comment at a Time**: Process comments sequentially, don't batch. Each comment gets its own commit.
+
+8. **Comment Explanations**: Some comments may not require code changes. In those cases, reply with a clear explanation of why the code is correct as-is.
+
+9. **Poe Task Automation**: The `pr-address-comment` poe task handles finding the thread ID, adding the reply, resolving the thread, and adding the "On behalf of @username" footer automatically.
+
+10. **Testing**: ALWAYS run the full test suite via `poe quality`. Don't skip tests even if changes seem minor.
+
+## Example Complete Flow
+
+```bash
+# 1. Get PR info
+PR_NUMBER=$(gh pr view --json number --jq '.number')
+
+# 2. Fetch unresolved comments
+gh api graphql [...] # Parse to get COMMENT_ID, AUTHOR, BODY, PATH, LINE
+
+# 3. Read file context
+# Use Read tool on PATH
+
+# 4. Analyze comment
+# Present analysis to user:
+# "Comment #123 from @copilot suggests changing the return type from str to Optional[str].
+#  I propose to:
+#  1. Update the function signature in user_config.py line 45
+#  2. Add None checks in calling code
+#
+#  Do you approve this approach? (yes/no/modify)"
+
+# 5. WAIT FOR USER APPROVAL
+
+# 6. After approval, make fix
+# Use Edit tool to fix code
+
+# 7. Run quality gates
+uv run poe fix
+uv run poe quality
+
+# 8. Commit
+STORY_ID=$(git branch --show-current)
+git add .
+git commit -m "fix(${STORY_ID}): Address review comment #123 - fix type annotation
+
+Corrected return type annotation from str to Optional[str] to match
+actual implementation that can return None.
+
+Addresses: Comment #123 from copilot
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+
+# 9. Push
+git push
+
+# 10. Watch CI
+RUN_ID=$(gh run list --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run watch $RUN_ID
+
+# 11. Reply and resolve (once CI is green)
+COMMIT_HASH=$(git log -1 --format=%h)
+PR_NUMBER=4 COMMENT_ID=123 REPLY_BODY="**Fixed** - Corrected return type annotation.
+
+**Changes:**
+- Changed return type from \`str\` to \`Optional[str]\`
+- Added None check in calling code
+
+**Commit:** ${COMMIT_HASH}" uv run poe pr-address-comment
+```
+
+## Begin Execution
+
+Start by fetching the PR information and unresolved comments for the current branch, then proceed through each comment systematically following the workflow above.
+
+**Remember**: ALWAYS stop and get user approval before making any code changes or posting any replies.

--- a/.claude/commands/review-story.md
+++ b/.claude/commands/review-story.md
@@ -1,0 +1,1137 @@
+---
+description: Comprehensive story review - quality validation with optional file edits
+allowed-tools: "*"
+---
+
+# Story Review: Quality Validation + Ticket Synchronization
+
+You are tasked with performing a comprehensive review of a story with dual capabilities:
+
+1. **Quality Validation** (always): Check story completeness, coherence, alignment with roadmap
+2. **Ticket Sync** (optional, in-progress only): Update tickets to match git reality
+
+## Overall Workflow
+
+1. **Gather User Context** - Ask if standard or focused review
+2. **Verify Story Branch & Detect Mode** - Check branch, count commits
+3. **Deep Analysis** - Use Task agent to analyze story quality + git state
+4. **Present Combined Report** - Show quality score + issues + proposed edits
+5. **Get User Approval** ⚠️ **REQUIRED** - Present all edits and wait for approval
+6. **Execute Edits** - Apply approved changes to ticket files
+7. **Print Final Report** - Show improvements and next steps
+
+---
+
+## Step 0: Gather User Context
+
+⚠️ **INITIAL PROMPT**
+
+Before starting the review, ask the user what type of review they want:
+
+```markdown
+# 📋 Story Review Setup
+
+You're about to review the story on this branch.
+
+**Review Options:**
+
+1. **standard** - Complete quality validation + ticket sync
+   - Checks all quality categories (completeness, hierarchy, roadmap alignment, etc.)
+   - Validates ticket accuracy vs git commits (if in-progress)
+   - Comprehensive but no specific focus
+
+2. **focused** - Targeted review with your specific context
+   - Same checks as standard, but prioritizes your concerns
+   - You provide context about what to focus on
+   - Agent highlights findings related to your focus areas
+
+**Which type of review?** (standard/focused)
+```
+
+Wait for user response.
+
+**If "standard":**
+- Set `REVIEW_TYPE = "standard"`
+- Set `USER_CONTEXT = ""`
+- Proceed to Step 1
+
+**If "focused":**
+- Set `REVIEW_TYPE = "focused"`
+- Ask follow-up:
+  ```markdown
+  **What should this review focus on?**
+
+  Examples:
+  - "Check if BDD scenarios match acceptance criteria"
+  - "Validate task estimates are realistic"
+  - "Ensure technical design is complete"
+  - "Review new tasks added during implementation"
+
+  Your focus (or press Enter for standard review):
+  ```
+
+  Wait for user input.
+  - If user provides text: Set `USER_CONTEXT = <their input>`
+  - If user presses Enter (empty): Treat as standard review
+  - Proceed to Step 1
+
+**If neither:**
+- Ask again with validation: "Please choose 'standard' or 'focused'"
+
+---
+
+## Step 1: Verify Story Branch & Detect Mode
+
+Check that we're on a story branch and determine mode:
+
+```bash
+git branch --show-current
+```
+
+**Validation:**
+- Branch name must match pattern `STORY-NNNN.N.N` (e.g., STORY-0001.1.2)
+- If NOT on a story branch:
+  - Ask user: "Not on a story branch. Current branch: [BRANCH]. Would you like to:"
+    1. Create a new story branch (provide story ID)
+    2. Switch to existing story branch (list available)
+    3. Exit
+  - Wait for user decision before proceeding
+
+**Extract Story Info:**
+
+From the branch name (e.g., `STORY-0001.1.2`), construct the necessary paths:
+
+**Example for STORY-0001.1.2:**
+- Story ID: `STORY-0001.1.2`
+- Epic ID: `EPIC-0001.1` (first two numbers)
+- Initiative ID: `INIT-0001` (first number)
+- Story path: `docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/README.md`
+- Epic path: `docs/tickets/INIT-0001/EPIC-0001.1/README.md`
+- Initiative path: `docs/tickets/INIT-0001/README.md`
+
+**Pattern:**
+- For `STORY-NNNN.E.S`:
+  - Initiative: `INIT-NNNN`
+  - Epic: `EPIC-NNNN.E`
+  - Story: `STORY-NNNN.E.S`
+  - Story dir: `docs/tickets/INIT-NNNN/EPIC-NNNN.E/STORY-NNNN.E.S/`
+
+**Detect Mode:**
+
+```bash
+# Count commits on current branch vs main
+git rev-list --count main..HEAD
+```
+
+- **0 commits** → `pre-work` mode (story not started)
+- **N commits** → `in-progress` mode (work underway)
+
+---
+
+## Step 2: Gather Context with Task Agent
+
+Use the Task agent (general-purpose) to perform deep analysis:
+
+```markdown
+**Task Agent Prompt:**
+
+Perform comprehensive story review combining quality validation and git reality analysis.
+
+**Story Context:**
+- Story ID: [STORY_ID from branch]
+- Story path: docs/tickets/INIT-[NNNN]/EPIC-[NNNN.E]/STORY-[NNNN.E.S]/README.md
+- Epic ID: EPIC-[NNNN.E]
+- Epic path: docs/tickets/INIT-[NNNN]/EPIC-[NNNN.E]/README.md
+- Initiative ID: INIT-[NNNN]
+- Initiative path: docs/tickets/INIT-[NNNN]/README.md
+- Mode: {pre-work | in-progress}
+
+**IMPORTANT:** Construct paths from the branch name. For example, branch `STORY-0001.1.2` means:
+- Initiative: INIT-0001
+- Epic: EPIC-0001.1
+- Story: STORY-0001.1.2
+
+**Review Type:** {REVIEW_TYPE from Step 0}
+
+{IF REVIEW_TYPE == "focused"}
+**User Focus Context:**
+
+{USER_CONTEXT from Step 0}
+
+**Instructions:**
+- Perform all standard validation checks
+- Pay special attention to areas mentioned in user focus
+- In your output, create a dedicated "Focus Area Analysis" section
+- Highlight findings that directly relate to user's context
+- Prioritize these findings in proposed edits
+{ENDIF}
+
+**Analysis Required:**
+
+### Part 1: Quality Validation (ALWAYS)
+
+**Read All Context Files:**
+1. Story README: ${STORY_DIR}/README.md
+2. All task files: ${STORY_DIR}/TASK-*.md
+3. Parent epic: ${EPIC_DIR}/README.md
+4. Sibling stories: All other STORY-${INIT}-${EPIC}.* in same epic directory
+5. Initiative: ${INIT_DIR}/README.md
+6. Roadmap: docs/vision/ROADMAP.md
+7. Root CLAUDE.md and relevant nested CLAUDE.md files
+
+**Validation Categories:**
+
+#### 1. Story Completeness (10 checks)
+- ✅ User story follows "As a/I want/So that" format
+- ✅ All acceptance criteria are testable (not vague)
+- ✅ All child tasks listed and linked
+- ✅ Story points estimated and match task hours sum
+- ✅ BDD scenarios written in Gherkin (if applicable)
+- ✅ Technical design section present and detailed
+- ✅ Success metrics defined and measurable
+- ✅ Dependencies documented
+- ✅ Risks identified with mitigations
+- ✅ Example code/schemas provided for complex logic
+
+#### 2. Hierarchy Consistency (6 checks base + 2 if in-progress)
+- ✅ Story aligns with parent epic's goals
+- ✅ Story doesn't duplicate sibling stories
+- ✅ Story contributes to epic's completion criteria
+- ✅ Story points fit within epic's total
+- ✅ Prerequisites from other stories identified
+- ✅ No conflicting assumptions with siblings
+{IF in-progress}
+- ✅ New tasks (if any) align with story scope
+- ✅ Task additions documented in story progress/notes
+{ENDIF}
+
+#### 3. Roadmap Alignment (5 checks base + 1 if in-progress)
+- ✅ Story contributes to initiative objectives
+- ✅ Story aligns with version planning milestones
+- ✅ Story supports success metrics from roadmap
+- ✅ Story doesn't contradict core design principles
+- ✅ Technology choices match approved stack
+{IF in-progress}
+- ✅ Scope changes (if any) align with roadmap priorities
+{ENDIF}
+
+#### 4. Implementation Readiness (10 checks base + 1 if in-progress)
+- ✅ Every task has concrete steps (not "implement X")
+- ✅ File paths and module names specified
+- ✅ BDD scenarios have corresponding step definitions planned
+- ✅ Test coverage targets specified (e.g., ≥85%)
+- ✅ Example code/pseudocode provided for complex logic
+- ✅ Edge cases identified in scenarios
+- ✅ Error handling paths specified
+- ✅ All external APIs/libraries identified
+- ✅ Solution complexity matches problem scope (not over-architected)
+- ✅ Tasks avoid premature optimization (implement MVP first, optimize when metrics show need)
+{IF in-progress}
+- ✅ Implementation matches task specifications
+{ENDIF}
+
+**Anti-Overengineering Detection Patterns:**
+
+For checks 9-10, flag issues when tasks propose complexity without clear justification:
+
+- **Caching/Memoization** for:
+  - Small files (<10KB) loaded once per process
+  - CLI tools where each invocation is a new process
+  - Data that changes frequently
+  - No performance metrics showing it's needed
+
+- **Abstraction Layers** when:
+  - Only one concrete implementation exists
+  - No indication multiple implementations will be needed
+  - Adds complexity without solving a real problem
+  - Uses terms like "future-proof" without roadmap evidence
+
+- **Performance Optimizations** before:
+  - Performance metrics exist showing a problem
+  - Profiling data identifies the bottleneck
+  - User-facing performance requirements exist
+  - MVP implementation is complete
+
+- **Premature Refactoring** such as:
+  - Large refactors when targeted fixes would work
+  - Breaking working code "for cleanliness" without quality threshold violations
+  - Architectural changes without clear requirements driving them
+
+**Valid Complexity** (do NOT flag):
+- Security hardening (always appropriate)
+- Type safety and validation (catches bugs early)
+- Error handling for user-facing features
+- Test coverage improvements
+- Documentation
+- Fixing actual quality threshold violations (complexity, line limits, etc.)
+
+When flagging overengineering, propose specific edits like:
+- Remove unnecessary task entirely
+- Reduce task scope (e.g., "refactor entire module" → "fix specific complexity violation")
+- Move to future story with "if metrics show need" condition
+
+#### 5. Specification Ambiguity Detection (8 checks)
+- 🔍 Vague terms: "simple", "basic", "handle", "support", "improve"
+- 🔍 Missing details: "TBD", "etc.", "and so on", "as needed"
+- 🔍 Implicit assumptions: "obviously", "clearly", "simply"
+- �� Unquantified requirements: "fast", "efficient", "user-friendly"
+- 🔍 Missing acceptance criteria for edge cases
+- 🔍 Incomplete error handling specifications
+- 🔍 Missing validation rules
+- 🔍 Newly added tasks with vague descriptions
+
+{IF in-progress}
+#### 6. Coherence Validation (6 checks - IN-PROGRESS MODE ONLY)
+- 🔍 Git commits match story scope (no scope creep)
+- 🔍 Completed tasks align with acceptance criteria
+- 🔍 New tasks don't conflict with completed work
+- 🔍 Task sequence makes logical sense
+- 🔍 Progress percentage matches reality
+- 🔍 Story status reflects actual state
+{ENDIF}
+
+**For Each Failed Check:**
+- Document: Location (file:line), Current state, Issue description, Proposed fix, Impact/Priority
+
+### Part 2: Ticket Sync Analysis (IN-PROGRESS MODE ONLY)
+
+**Analyze Git State:**
+- Committed changes: `git diff main...HEAD --stat`
+- Committed changes detail: `git diff main...HEAD`
+- Uncommitted changes: `git status --short`
+- Uncommitted changes detail: `git diff`
+- Recent commits: `git log --oneline main..HEAD`
+
+**Compare Ticket vs Reality:**
+
+For each task in the story:
+- What does the task say it should accomplish?
+- What files should be modified according to task description?
+- Are those files actually modified in git diff?
+- Are task checkboxes accurate?
+- Is task status accurate (🔵 Not Started / 🟡 In Progress / ✅ Complete)?
+- Are actual hours recorded?
+
+**Identify Ticket Drift:**
+- Tasks marked incomplete but code is done
+- Tasks marked complete but code is missing
+- Progress percentages that don't match reality
+- Missing context or documentation in tickets
+- Status inconsistencies (task complete but story not updated)
+- Parent epic/initiative progress bars out of sync
+- New tasks added but not documented in story header
+- Task additions not explained in story notes
+
+**For Each Drift Item:**
+- Specify: Which file needs updating (exact path), What section/field needs changing, Old value vs new value, Justification based on git diff
+
+---
+
+**Output Format:**
+
+Return a structured analysis with:
+
+## 1. Review Configuration
+- Review Type: {standard | focused}
+- Mode: {pre-work | in-progress}
+- Commits on branch: {0 | N}
+{IF focused}
+- User Focus: "{USER_CONTEXT}"
+{ENDIF}
+
+{IF focused}
+## 2. Focus Area Analysis
+
+**User Requested Focus:**
+"{USER_CONTEXT}"
+
+**Findings Related to Focus:**
+[List specific findings that directly address user's focus context]
+[If no issues found in focus area, explicitly state that]
+
+**Priority Recommendations:**
+[Recommendations specifically for the focus area]
+
+---
+{ENDIF}
+
+## {2 or 3}. Quality Validation Summary
+
+**Overall Quality Score**: XX% ({Ready | Ready with Issues | Needs Review | Not Ready})
+
+### Category Scores:
+- Story Completeness: XX% (N/10 checks)
+- Hierarchy Consistency: XX% ({6 | 8} checks)
+- Roadmap Alignment: XX% ({5 | 6} checks)
+- Implementation Readiness: XX% ({10 | 11} checks)
+- Specification Ambiguity: XX% (8 checks - higher is better)
+{IF in-progress}
+- Coherence Validation: XX% (6 checks)
+{ENDIF}
+
+### Quality Issues Found: [count]
+[List each issue with: Type, Priority (High/Medium/Low), Location, Current state, Proposed fix, Impact]
+
+## 3. Ticket Sync Analysis (IN-PROGRESS ONLY)
+
+**Git Activity Summary:**
+- Files modified: [count]
+- Lines added/removed: +X -Y
+- Commits on branch: [count]
+- Uncommitted changes: [yes/no with count]
+
+**Task Status Validation Table:**
+
+| Task | Ticket Status | Git Evidence | Match? |
+|------|---------------|--------------|--------|
+| TASK-X.X.X.X | ✅ Complete | ✅ Commit abc123 | ✅ |
+| TASK-Y.Y.Y.Y | 🔵 Not Started | ❌ No commit | ✅ |
+
+**Ticket Drift Found**: [count]
+[List each drift with: Type, Location, Current value, Git reality, Proposed fix]
+
+## 4. Proposed File Edits
+
+**Total Edits**: [count quality + count sync] across [N] files
+
+### Quality Fix Edits ([count])
+For each quality issue that can be fixed with an edit:
+- File: [exact path]
+- Edit type: [Add missing section | Replace vague text | etc.]
+- OLD: [exact current text to find]
+- NEW: [exact replacement text]
+- Reason: [why this fixes the issue]
+
+{IF in-progress}
+### Ticket Sync Edits ([count])
+For each ticket drift that needs fixing:
+- File: [exact path]
+- Edit type: [Update status | Update progress | etc.]
+- OLD: [exact current text]
+- NEW: [exact replacement text]
+- Reason: [git evidence justifying change]
+{ENDIF}
+
+## 5. Comparative Analysis
+
+**Sibling Stories:**
+- STORY-X.X.X: Quality XX% (status)
+- STORY-Y.Y.Y: Quality YY% (status)
+- Current story: Quality ZZ%
+
+**Best Practices:**
+- Applied: [list practices found in story]
+- Missing: [list practices missing vs high-quality siblings]
+
+## 6. Recommendations
+
+{IF pre-work}
+**Before Starting Work:**
+[List specific actions with time estimates to improve quality score]
+{ELSE}
+**Before Next Commit:**
+[List quality fixes and ticket sync actions with time estimates]
+{ENDIF}
+
+**Estimated Time to Address All Issues**: [X] minutes
+**Quality Score Improvement**: XX% → YY%
+{IF in-progress}
+**Ticket Accuracy Improvement**: [N] drift → 0 drift
+{ENDIF}
+```
+
+**Agent Configuration:**
+- Type: general-purpose
+- Mode: Research only (no code changes yet)
+- Output: Detailed analysis with exact file edit specifications
+
+---
+
+## Step 3: Present Combined Report to User
+
+⚠️ **MANDATORY STOP POINT**
+
+After receiving the Task agent's analysis, present the complete findings to the user.
+
+### Report Format
+
+```markdown
+# 📋 Story Review Report: ${STORY_ID}
+
+**Branch**: ${BRANCH}
+**Review Type**: {Standard | Focused}
+{IF focused}
+**Focus Area**: "{USER_CONTEXT}"
+{ENDIF}
+**Review Mode**: {Pre-Work (0 commits) | In-Progress (N commits)}
+**Story Status**: {🔵 Not Started | 🟡 In Progress | ✅ Complete}
+
+═══════════════════════════════════════════════════════════
+
+{IF focused}
+## Focus Area Analysis
+
+**You asked us to focus on:**
+> {USER_CONTEXT}
+
+**Findings Related to Your Focus:**
+
+{agent's focus area findings}
+
+**Recommendations:**
+
+{agent's focus area recommendations}
+
+═══════════════════════════════════════════════════════════
+{ENDIF}
+
+## Quality Validation
+
+**Overall Quality Score**: ████████░░ XX% ({Ready | Ready with Issues | Needs Review})
+
+### Readiness Breakdown
+
+[For each category, show progress bar + score + list of checks with ✅/⚠️]
+
+#### 1. Story Completeness: ██████████ 100% (10/10 checks)
+✅ User story format correct
+✅ Acceptance criteria testable
+...
+
+#### 2. Hierarchy Consistency: ████████░░ 83% (5/6 checks)
+✅ Aligns with epic goals
+⚠️ **ISSUE**: [Description]
+...
+
+[Continue for all categories]
+
+---
+
+### 🚨 Quality Issues Found ([count] total)
+
+#### High Priority ([count])
+1. **[Issue Title]** (Category)
+   - **Location**: [file:line]
+   - **Current**: [what's there now]
+   - **Fix**: [what it should be]
+   - **Impact**: [why this matters]
+
+[List all high priority issues]
+
+#### Medium Priority ([count])
+[List all medium priority issues]
+
+#### Low Priority ([count])
+[List all low priority issues]
+
+═══════════════════════════════════════════════════════════
+
+{IF in-progress}
+## Ticket Synchronization
+
+**Git Activity Summary**:
+- Commits: [N] commits on ${BRANCH}
+- Files: [N] files modified
+- Changes: +[additions] -[deletions]
+- Uncommitted: [N files or "None"]
+
+### Task Status Validation
+
+[Show table from agent analysis]
+
+### Ticket Drift
+
+{IF drift found}
+**Status**: ⚠️ [N] discrepancies found
+
+[List each drift item with details]
+{ELSE}
+**Status**: ✅ All tickets match git reality (0 discrepancies)
+
+All ticket documentation is accurate and matches implementation:
+- Task statuses are correct
+- Progress percentages match reality
+- All checkboxes reflect actual work completed
+- Parent epic/initiative properly updated
+{ENDIF}
+
+═══════════════════════════════════════════════════════════
+{ENDIF}
+
+## Proposed File Edits
+
+{IF no edits needed}
+✅ **No edits needed** - Story is {ready | accurate}
+
+{IF pre-work}
+Story meets quality standards for starting work.
+{ELSE}
+All documentation matches git reality.
+{ENDIF}
+
+{ELSE}
+**Total**: {N quality + M sync} edits proposed across [X] files
+
+### Quality Fix Edits ([N] edits)
+
+[For each quality fix:]
+
+**File**: `[path]`
+
+Edit: [Description]
+\`\`\`
+OLD (line [N]):
+[exact current text]
+
+NEW:
+[exact replacement text]
+\`\`\`
+Reason: [explanation]
+
+---
+
+{IF in-progress}
+### Ticket Sync Edits ([M] edits)
+
+[For each sync fix:]
+
+**File**: `[path]`
+
+Edit: [Description]
+\`\`\`
+OLD (line [N]):
+[exact current text]
+
+NEW:
+[exact replacement text]
+\`\`\`
+Reason: [git evidence]
+
+---
+{ENDIF}
+
+### Impact Assessment
+
+{IF pre-work}
+**Quality Improvement**: XX% → YY% (after fixes)
+**Time to Execute**: ~[N] minutes
+{ELSE}
+**Quality Improvement**: XX% → YY%
+**Ticket Accuracy**: [M] drift → 0 drift ✅
+**Time to Execute**: ~[N] minutes
+{ENDIF}
+
+═══════════════════════════════════════════════════════════
+
+## Comparative Analysis
+
+### Sibling Stories in ${EPIC_ID}:
+[Show quality scores from agent analysis]
+
+### Best Practices Applied/Missing:
+[Show from agent analysis]
+
+═══════════════════════════════════════════════════════════
+
+## Recommended Actions
+
+{IF pre-work}
+### Before Starting Work:
+[Numbered list from agent recommendations with time estimates]
+
+**Total Time**: ~[X] minutes to reach [target]% readiness
+{ELSE}
+### Before Next Commit:
+[Numbered list from agent recommendations]
+
+**Total Time**: ~[X] minutes to restore quality/accuracy
+{ENDIF}
+
+═══════════════════════════════════════════════════════════
+
+## Approval & Execution
+
+{IF edits proposed}
+**Do you approve these file edits?** (yes/no/modify)
+
+Options:
+- **yes**: Execute all proposed edits
+- **no**: Skip all edits (issues documented for manual fix)
+- **modify**: Discuss which edits to apply
+{ELSE}
+**No edits required - story is {ready | accurate}! ✨**
+
+{IF pre-work}
+Proceed with starting work on TASK-${FIRST_TASK}.
+{ELSE}
+Continue with next pending task or create PR if story complete.
+{ENDIF}
+{ENDIF}
+```
+
+**CRITICAL:** Do not make any file edits until user explicitly approves with "yes".
+
+---
+
+## Step 4: Execute Edits (After Approval)
+
+**Only proceed if:**
+- User approved with "yes"
+- Edits were proposed in Step 3
+
+**Update Order:** (dependencies matter)
+1. Task files (TASK-*.md) - lowest level
+2. Story README.md - aggregates tasks
+3. Epic README.md - aggregates stories
+4. Initiative README.md - aggregates epics
+
+**For Each Edit from Agent Analysis:**
+
+Use the Edit tool with exact OLD and NEW strings from agent's "Proposed File Edits" section.
+
+```python
+# Example: Quality fix
+Edit(
+    file_path="docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/README.md",
+    old_string="## Dependencies\n\n- Parent story created",
+    new_string="## Dependencies\n\n- Requires STORY-0001.1.1 (CLI Framework) complete\n- Parent story created"
+)
+
+# Example: Ticket sync fix
+Edit(
+    file_path="docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/README.md",
+    old_string="**Progress**: ████░░░░░░ 40% (2/5 tasks complete)",
+    new_string="**Progress**: ████████░░ 80% (4/5 tasks complete)"
+)
+```
+
+**Error Handling:**
+- If Edit fails (non-unique string), show error and ask user for guidance
+- Continue with remaining edits even if one fails
+- Track which edits succeeded vs failed
+
+---
+
+## Step 5: Print Final Report
+
+Print a comprehensive report based on whether edits were made.
+
+### Variant A: Edits Were Made
+
+If edits were executed (came from Step 4):
+
+```markdown
+# ✨ Story Review Complete: ${STORY_ID}
+
+**Branch**: ${BRANCH}
+**Review Type**: {Standard | Focused}
+{IF focused}
+**Focus Area**: "{USER_CONTEXT}"
+{ENDIF}
+**Date**: [current date]
+**Mode**: {Pre-Work | In-Progress}
+
+---
+
+{IF focused}
+## Focus Area Summary
+
+**Your Focus:** "{USER_CONTEXT}"
+
+**Status:**
+{IF issues found in focus area}
+⚠️  Issues found and addressed (see edits below)
+{ELSE}
+✅ No issues found in focus area - meets expectations
+{ENDIF}
+
+---
+{ENDIF}
+
+## Summary
+
+✅ **Edits Completed**: [N] files modified
+⚠️ **Edit Failures**: [M] failures (if any)
+
+### Quality Improvement
+- **Before**: [XX]% quality score
+- **After**: [YY]% quality score
+- **Improvement**: +[ZZ] points ✨
+
+{IF in-progress}
+### Ticket Accuracy Improvement
+- **Before**: [N] discrepancies
+- **After**: 0 discrepancies ✅
+- **Progress**: Now matches git reality
+{ENDIF}
+
+---
+
+## Files Updated
+
+[List each file with changes made]
+
+1. **[path]/TASK-X.md**
+   - Added step definition plan
+   - Clarified vague description
+
+2. **[path]/README.md**
+   - Added prerequisite documentation
+   - Quantified acceptance criteria
+   {IF in-progress}
+   - Updated progress percentage
+   - Documented task additions
+   {ENDIF}
+
+3. **[path]/EPIC-X.md** (if in-progress)
+   - Updated epic progress bar
+   - Updated story status in table
+
+---
+
+{IF pre-work}
+## Story Readiness
+
+**Status**: ✅ Ready to Start Work
+
+Story is now complete, cohesive, and unambiguous:
+- All specifications measurable
+- Implementation steps concrete
+- Dependencies documented
+- Aligned with epic/roadmap
+
+### Next Steps
+
+1. **Begin work**: Start with [FIRST_TASK_ID]
+2. **Follow BDD/TDD**: Write tests first, then implement
+3. **Commit after each task**: Use format `feat([TASK_ID]): description`
+4. **Run `/review-story` again**: If adding tasks mid-work
+
+{ELSE}
+## Story Status
+
+**Status**: ✅ Documentation Accurate
+
+All ticket documentation now matches implementation reality:
+- Task statuses reflect git commits
+- Progress percentages accurate
+- New tasks properly documented
+- Parent tickets updated
+
+### Next Steps
+
+{IF story complete}
+**Story appears complete! Consider:**
+1. Push branch: `git push -u origin ${BRANCH}`
+2. Create PR: `gh pr create --title "${STORY_ID}: [title]"`
+3. Monitor CI: `gh run watch`
+{ELSE}
+**Continue implementation:**
+1. Review next pending task: [NEXT_TASK_ID]
+2. Run quality gates: `uv run poe quality`
+3. Commit when task complete
+{ENDIF}
+{ENDIF}
+
+---
+
+## Quality Metrics
+
+**Specification Quality**: [YY]% (Agent-Friendly)
+- Strengths: [from analysis]
+- Improvements made: [what was fixed]
+
+{IF in-progress}
+**Tracking Discipline**: [score]% (Excellent/Good/Needs Work)
+- Commits reference task IDs: ✅
+- Statuses match reality: ✅
+- Progress tracking accurate: ✅
+{ENDIF}
+
+---
+
+**Review completed successfully! ✨**
+```
+
+### Variant B: No Edits Made
+
+If user declined edits OR no edits were needed:
+
+```markdown
+# 📋 Story Review Complete: ${STORY_ID}
+
+**Branch**: ${BRANCH}
+**Review Type**: {Standard | Focused}
+{IF focused}
+**Focus Area**: "{USER_CONTEXT}"
+{ENDIF}
+**Date**: [current date]
+**Mode**: {Pre-Work | In-Progress}
+
+---
+
+{IF focused}
+## Focus Area Summary
+
+**Your Focus:** "{USER_CONTEXT}"
+
+**Status:**
+{IF issues exist in focus area}
+⚠️  Issues remain (see above for details)
+{ELSE}
+✅ No issues found in focus area - meets expectations
+{ENDIF}
+
+---
+{ENDIF}
+
+## Summary
+
+{IF user declined}
+⏭️ **Edits Skipped** - Issues remain in documentation
+
+You chose not to apply the proposed edits. Issues are documented above for manual resolution.
+{ELSE}
+✅ **No Edits Needed** - Story {meets quality standards | matches git reality}
+
+{IF pre-work}
+Story is complete and ready for implementation.
+{ELSE}
+All ticket documentation accurately reflects implementation.
+{ENDIF}
+{ENDIF}
+
+---
+
+## Current Status
+
+{IF pre-work}
+**Quality Score**: [XX]% ({Ready | Ready with Issues | Needs Review})
+
+{IF issues exist}
+**Remaining Issues**: [N] issues documented
+- High priority: [count]
+- Medium priority: [count]
+- Low priority: [count]
+
+You can:
+- Address issues manually before starting work
+- Run `/review-story` again after manual fixes
+- Proceed with work (quality improvements optional)
+{ELSE}
+**Quality**: Excellent - all validation checks passed ✅
+{ENDIF}
+
+### Next Steps
+
+{IF issues exist}
+**Option 1 (Recommended)**: Fix issues manually ([X] min)
+**Option 2**: Proceed with work (accept current quality)
+{ELSE}
+1. **Begin work**: Start with [FIRST_TASK_ID]
+2. **Follow BDD/TDD**: Write tests first
+3. **Commit after each task**: Use format `feat([TASK_ID]): description`
+{ENDIF}
+
+{ELSE}
+**Quality Score**: [XX]%
+{IF quality issues}
+**Quality Issues**: [N] specification issues remain
+{ELSE}
+**Quality**: Excellent ✅
+{ENDIF}
+
+{IF drift exists}
+**Ticket Drift**: [N] discrepancies remain
+- Task status mismatches: [count]
+- Progress inaccuracies: [count]
+- Undocumented changes: [count]
+
+You can:
+- Run `/review-story` again and approve edits
+- Update tickets manually
+- Continue work (tracking optional, not blocking)
+{ELSE}
+**Ticket Accuracy**: Perfect - matches git reality ✅
+{ENDIF}
+
+### Next Steps
+
+{IF story complete}
+**Story appears complete!**
+1. Push branch: `git push -u origin ${BRANCH}`
+2. Create PR: `gh pr create --title "${STORY_ID}: [title]"`
+{ELSE}
+**Continue implementation:**
+1. Review next task: [NEXT_TASK_ID]
+2. {Address quality/tracking issues | } Run quality gates
+3. Commit when complete
+{ENDIF}
+{ENDIF}
+
+---
+
+**Review completed! {✨ | Run again with approval to apply fixes.}**
+```
+
+---
+
+## Important Notes
+
+1. **Dual Validation**: Always check quality; add sync check if in-progress
+2. **Single Approval Gate**: Present complete edit plan, get one approval, then execute all
+3. **Update Order Matters**: Tasks → Story → Epic → Initiative (bottom-up)
+4. **Quality Scoring**:
+   - Pre-work: 5 categories, 39 total checks
+   - In-progress: 6 categories, 49 total checks
+   - Each category scored independently, average = overall score
+5. **Edit Precision**: Use exact OLD/NEW strings from agent analysis
+6. **Error Recovery**: Continue updates even if one fails, report all failures
+7. **Mode Auto-Detection**: Based on commit count, no user input needed
+8. **Flexibility**: User can decline edits and fix manually
+9. **No File Creation**: This command only EDITS existing tickets, never creates
+
+---
+
+## Thresholds & Scoring
+
+### Quality Score Interpretation
+- 95-100%: Ready to start / Ready to continue
+- 85-94%: Ready with minor issues
+- 70-84%: Needs review before proceeding
+- Below 70%: Not ready - significant work needed
+
+### Edit Types
+
+**Quality Fixes** (both modes):
+- Add missing documentation sections
+- Replace vague terms with concrete specifications
+- Quantify unquantified requirements
+- Add missing step definitions/examples
+- Clarify ambiguous task descriptions
+
+**Ticket Sync** (in-progress only):
+- Update task statuses to match commits
+- Adjust progress percentages
+- Document new task additions
+- Update parent epic/initiative progress
+- Record actual hours worked
+
+---
+
+## Example Complete Flow
+
+### Example 1: Standard Review
+
+```bash
+# User on story branch with 6 commits
+$ /review-story
+
+# 0. Gather user context
+Which type of review? (standard/focused)
+> standard
+
+# 1. Verify branch & detect mode
+Current branch: STORY-0001.1.2 ✓
+Mode: in-progress (6 commits)
+
+# 2. Launch Task agent (internal - user sees "Analyzing...")
+Analyzing story quality and git state...
+
+# 3. Present combined report
+# 📋 Story Review Report: STORY-0001.1.2
+# Review Type: Standard
+# Quality Score: 85%
+# Ticket Sync: 2 discrepancies
+# 5 edits proposed (3 quality + 2 sync)
+# [Shows all details...]
+Do you approve these file edits? (yes/no/modify)
+
+# 4. User approves
+yes
+
+# 5. Execute edits (user sees progress)
+Updating STORY-0001.1.2/README.md (3 edits)... ✓
+Updating TASK-0001.1.2.1.md (1 edit)... ✓
+Updating EPIC-0001.1/README.md (1 edit)... ✓
+
+# 6. Print final report
+# ✨ Story Review Complete: STORY-0001.1.2
+# Quality: 85% → 93% (+8 points)
+# Ticket accuracy: 2 drift → 0 drift ✅
+# [Shows improvements...]
+```
+
+### Example 2: Focused Review
+
+```bash
+# User on story branch, pre-work
+$ /review-story
+
+# 0. Gather user context
+Which type of review? (standard/focused)
+> focused
+
+What should this review focus on?
+> Check if BDD scenarios match acceptance criteria and have step definitions planned
+
+# 1. Verify branch & detect mode
+Current branch: STORY-0001.1.3 ✓
+Mode: pre-work (0 commits)
+
+# 2. Launch Task agent with focus context
+Analyzing story with focus on BDD scenarios...
+
+# 3. Present combined report
+# 📋 Story Review Report: STORY-0001.1.3
+# Review Type: Focused
+# Focus Area: "Check if BDD scenarios match acceptance criteria and have step definitions planned"
+
+## Focus Area Analysis
+
+**You asked us to focus on:**
+> Check if BDD scenarios match acceptance criteria and have step definitions planned
+
+**Findings Related to Your Focus:**
+- ✅ BDD scenarios exist and cover all 5 acceptance criteria
+- ⚠️  Step definition plan missing in TASK-0001.1.3.2
+- ⚠️  Scenario for edge case "empty config file" not found
+
+**Recommendations:**
+- Add step definition plan to TASK-0001.1.3.2
+- Add BDD scenario for edge case handling
+
+## Quality Validation
+# Overall Quality: 78%
+# 3 edits proposed (all focused on BDD alignment)
+# [Shows all details...]
+Do you approve these file edits? (yes/no/modify)
+
+# 4. User approves
+yes
+
+# 5. Execute edits
+Updating TASK-0001.1.3.2.md (1 edit)... ✓
+Updating STORY-0001.1.3/README.md (2 edits)... ✓
+
+# 6. Print final report
+# ✨ Story Review Complete: STORY-0001.1.3
+# Review Type: Focused
+# Focus Area: BDD scenarios alignment
+# Quality: 78% → 92% (+14 points)
+# Focus issues: 2 found and fixed ✅
+```
+
+---
+
+## Begin Execution
+
+1. **Gather user context** - Ask standard vs focused, collect context if focused
+2. **Verify branch & detect mode** - Check STORY-* branch, count commits
+3. **Launch Task agent** - Analyze quality (always) + sync (if in-progress), with optional focus context
+4. **Present combined report** - Show quality + sync + proposed edits (+ focus area if focused)
+5. **Two paths:**
+   - **If edits proposed**: Get approval → Execute edits → Print report (Variant A)
+   - **If no edits OR user declines**: Print status report (Variant B)
+
+**Remember:** Always present findings to user. Only make edits after explicit approval with "yes".

--- a/.claude/commands/start-next-task.md
+++ b/.claude/commands/start-next-task.md
@@ -1,0 +1,1494 @@
+---
+description: Execute next pending task with implementation plan approval and quality gates
+allowed-tools: "*"
+---
+
+# Start Next Task: Implementation Execution with Quality Gates
+
+You are tasked with executing the next pending task in a story-driven workflow with strict quality gates and manual approval checkpoints.
+
+## Overall Workflow
+
+1. **Verify Story Branch** - Check branch name matches STORY-* pattern
+2. **Load Story Context** - Read story, tasks, epic, initiative, roadmap, CLAUDE.md files
+3. **Identify Next Task** - Find first task with status "🔵 Not Started"
+4. **Validate Prerequisites** - Ensure previous tasks complete, dependencies met
+5. **Deep Analysis** - Use Task agent to create detailed implementation plan
+6. **Present Plan** ⚠️ **REQUIRED APPROVAL** - Wait for user "yes" before proceeding
+7. **Execute Implementation** - Use Task agent to implement (BDD/TDD workflow)
+8. **Run Quality Gates** - All must pass (ruff, mypy, pytest, coverage)
+9. **Human QA Checkpoint** ⚠️ **REQUIRED APPROVAL** - Wait for user "yes" before ticket updates
+10. **Update Tickets** - Task status, hours, story progress, epic (if needed)
+11. **Commit Changes** - Create atomic commit with proper format (tickets + implementation)
+12. **Push to Remote** - Optional, user confirms
+13. **Final Report** - Summary and next steps
+
+---
+
+## Step 1: Verify Story Branch
+
+Check that we're on a story branch and extract IDs:
+
+```bash
+git branch --show-current
+```
+
+**Validation:**
+- Branch name must match pattern `STORY-NNNN.N.N` (e.g., STORY-0001.1.2)
+- If NOT on a story branch:
+  - Error message: "Not on a story branch. Current branch: [BRANCH]"
+  - Guidance: "Switch to story branch: git checkout STORY-XXXX"
+  - Exit
+
+**Extract IDs from branch name:**
+
+From branch `STORY-0001.1.2`:
+- Story ID: `STORY-0001.1.2`
+- Epic ID: `EPIC-0001.1` (first two numbers)
+- Initiative ID: `INIT-0001` (first number)
+
+**Construct paths:**
+- Story dir: `docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/`
+- Story README: `docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/README.md`
+- Task pattern: `docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-*.md`
+- Epic README: `docs/tickets/INIT-0001/EPIC-0001.1/README.md`
+- Initiative README: `docs/tickets/INIT-0001/README.md`
+
+---
+
+## Step 2: Load Story Context
+
+Read all context files to understand the work:
+
+**Required files:**
+1. Story README: `${STORY_DIR}/README.md`
+2. All task files: `${STORY_DIR}/TASK-*.md` (use Glob to find)
+3. Parent epic: `${EPIC_DIR}/README.md`
+4. Initiative: `${INIT_DIR}/README.md`
+5. Roadmap: `docs/vision/ROADMAP.md`
+6. Root CLAUDE.md: `CLAUDE.md`
+7. Relevant nested CLAUDE.md files based on task type:
+   - If BDD/E2E: `tests/e2e/CLAUDE.md`
+   - If TDD/Unit: `tests/unit/CLAUDE.md`
+   - If Docs: `docs/CLAUDE.md`
+   - If Architecture: `docs/architecture/CLAUDE.md`
+   - Tickets workflow: `docs/tickets/CLAUDE.md` (always)
+8. TUI_GUIDE.md (if CLI-related story): `TUI_GUIDE.md`
+
+Use Read tool for each file. Track which files exist vs don't exist.
+
+---
+
+## Step 3: Identify Next Task
+
+Find the first pending task:
+
+**Logic:**
+1. Parse all TASK-*.md files
+2. Extract task ID and status from each
+3. Sort tasks by ID (numerical order)
+4. Find first task with status "🔵 Not Started"
+
+**Status indicators to recognize:**
+- `🔵 Not Started` or `**Status**: 🔵 Not Started`
+- `🟡 In Progress` or `**Status**: 🟡 In Progress`
+- `✅ Complete` or `**Status**: ✅ Complete`
+
+**Edge cases:**
+
+**Case A: Task already in progress**
+```markdown
+⚠️  Task {TASK_ID} is already 🟡 In Progress
+
+This suggests work started but not completed.
+
+Options:
+1. **continue**: Continue from where it was left off
+2. **restart**: Reset to 🔵 Not Started and start fresh
+3. **cancel**: Exit (you can fix manually)
+
+Choose: (continue/restart/cancel)
+```
+
+Wait for user input. If "restart", edit task file to change status to 🔵, then proceed. If "cancel", exit.
+
+**Case B: All tasks complete**
+```markdown
+✓ All tasks complete!
+
+Story: {STORY_ID} (100% complete)
+
+Next steps:
+1. Run `/review-story` for final validation
+2. Create PR: `gh pr create --title "{STORY_ID}: {title}"`
+```
+
+Exit successfully.
+
+**Case C: No next task (gaps in sequence)**
+```markdown
+⚠️  No pending tasks, but story not complete
+
+Completed: {list}
+In Progress: {list}
+Missing: Possible gap in task sequence?
+
+Manual review needed.
+```
+
+Exit.
+
+---
+
+## Step 4: Validate Prerequisites
+
+Check that prerequisites are met for the next task:
+
+**Checks:**
+1. **Previous tasks complete**: All tasks with lower IDs must be "✅ Complete"
+2. **Dependencies met**: Check Dependencies section in task/story
+3. **Required files exist**: If task says "refactor X", check that X exists
+4. **BDD scenarios exist**: If task is implementation, check that BDD scenarios exist
+
+**If prerequisites fail:**
+```markdown
+✗ Prerequisites not met for {TASK_ID}
+
+Required:
+  ✗ TASK-0001.1.2.1 must be complete (currently: 🟡 In Progress)
+  ✓ BDD scenarios exist in tests/e2e/features/cli.feature
+  ✗ Dependency: Parent story created (currently: not found)
+
+Complete prerequisites first, then retry.
+```
+
+Exit with error.
+
+---
+
+## Step 5: Deep Analysis with Task Agent
+
+Launch a Task agent (general-purpose) to create detailed implementation plan:
+
+**Agent Prompt:**
+```markdown
+Create a detailed implementation plan for TASK-{TASK_ID}: {Title}
+
+**Context Provided:**
+
+You have access to:
+- Story README with acceptance criteria, BDD scenarios, technical design
+- Task file with implementation checklist and requirements
+- Parent epic goals and context
+- Initiative objectives
+- Roadmap alignment
+- Root CLAUDE.md and nested CLAUDE.md files with workflow rules
+- TUI_GUIDE.md (if CLI-related task)
+
+**Task Details:**
+- Task ID: {TASK_ID}
+- Title: {Title}
+- Status: {Status}
+- Estimated Hours: {Hours}
+- Parent Story: {STORY_ID}
+- Parent Epic: {EPIC_ID}
+- Initiative: {INIT_ID}
+
+**Codebase Pattern Discovery (REQUIRED FIRST):**
+
+Before creating your implementation plan, you MUST discover and analyze existing patterns:
+
+1. **Test Fixtures Survey**
+   - Read ALL conftest.py files: `tests/conftest.py`, `tests/unit/conftest.py`, `tests/e2e/conftest.py`
+   - List all available fixtures with their purposes
+   - Identify fixture composition patterns (fixtures using other fixtures)
+   - Note factory fixtures for creating test data
+
+2. **Existing Test Patterns**
+   - Find similar test files in tests/unit/ and tests/e2e/
+   - Read 2-3 examples of tests similar to your task
+   - Extract common patterns: setup, assertions, mocks, parametrization
+   - Identify reusable step definitions (for E2E) or test helpers
+
+3. **Module Organization**
+   - Read existing modules in src/gitctx/ related to your task
+   - Note import patterns, class structure, error handling
+   - Find utility functions and common helpers
+   - Identify shared constants or configuration
+
+4. **Documentation Context**
+   - Read relevant nested CLAUDE.md files for your domain
+   - Note documented patterns and anti-patterns
+   - Extract fixture usage examples
+   - Understand security constraints (esp. for git operations)
+
+**Pattern Reuse Checklist:**
+
+Before proposing ANY new fixture, helper, or pattern, verify:
+
+- [ ] No existing fixture provides this functionality
+- [ ] Cannot compose existing fixtures to achieve this
+- [ ] Cannot use existing factory to generate test data
+- [ ] Not duplicating existing test patterns
+- [ ] Not reimplementing platform abstraction helpers
+
+**Your Mission:**
+
+Create a comprehensive implementation plan following strict BDD/TDD workflow principles.
+
+## Required Output Format
+
+### 1. Understanding
+- **What this task accomplishes** (1-2 sentences)
+- **How it fits in story/epic/initiative** (alignment)
+- **Dependencies and prerequisites** (already validated, just confirm)
+
+### 2. Pattern Reuse Analysis & BDD/TDD Strategy
+
+**First: List Discovered Reusable Patterns**
+
+From your pattern discovery, list what you found that applies to this task:
+
+**Available Fixtures:**
+
+- [List fixtures from conftest.py files relevant to this task]
+- [Specify which fixtures to use and why]
+
+**Existing Test Patterns:**
+
+- [List 2-3 similar test files found]
+- [Specify patterns to copy/adapt from those files]
+
+**Reusable Helpers:**
+
+- [List utility functions or platform helpers to use]
+- [Specify helper modules to import]
+
+**Then: Identify Your Development Phase**
+
+#### If BDD Phase (scenario writing):
+
+- Which scenarios to add/modify in tests/e2e/features/
+- **REUSE**: Which existing step definitions to reuse from tests/e2e/steps/
+- **NEW**: Which step definitions are truly new (justify why no existing step works)
+- **FIXTURES**: Which e2e fixtures to use (`e2e_git_repo`, `e2e_cli_runner`, etc.)
+- Exact file locations and Gherkin structure
+
+#### If TDD Phase (unit tests):
+
+- Which test files to create/modify in tests/unit/
+- **REUSE**: Which existing fixtures to use (`isolated_env`, `config_factory`, etc.)
+- **REUSE**: Which test patterns to copy from similar test files
+- **NEW**: What new fixtures needed (justify why existing ones insufficient)
+- **FIXTURES**: Specify exact fixture composition strategy
+- Expected failures and coverage targets
+
+#### If Implementation Phase:
+
+- Which source files to create/modify in src/
+- **REUSE**: Which existing modules/helpers to import and use
+- **REUSE**: Which patterns to follow from similar modules
+- Module structure and organization
+- Key classes/functions to implement
+- Error handling strategy
+
+#### If Refactoring Phase:
+
+- What to refactor and why
+- **REUSE**: Which patterns from other modules to adopt
+- Tests must stay green throughout
+- Code quality improvements (readability, maintainability)
+
+### 3. Step-by-Step Implementation Plan
+
+Provide concrete, actionable steps. Each step MUST include:
+
+1. **Step Number & Description**
+2. **File**: Exact absolute path (e.g., `/Users/bram/Code/gitctx-ai/gitctx/src/...`)
+3. **Action**: Read, Write (new file), or Edit (existing file)
+4. **Pattern Reuse**: State what existing pattern/fixture/helper this step uses
+   - Example: "Uses `isolated_env` fixture from tests/unit/conftest.py"
+   - Example: "Follows AAA pattern from tests/unit/core/test_config.py:10-28"
+   - Example: "Reuses `e2e_git_repo_factory` with custom params"
+   - Example: "Imports `is_windows()` helper from tests/conftest.py:38"
+5. **Content**: Specific changes (not vague like "implement X")
+   - For Write: Show file structure/skeleton
+   - For Edit: Show OLD and NEW content
+6. **Verification**: Exact command to verify this step worked
+
+**Example Good Step:**
+```
+**Step 3: Add BDD scenario for config init**
+- File: `tests/e2e/features/cli.feature`
+- Action: Edit (append new scenario after existing config scenarios)
+- Content:
+  ```gherkin
+  Scenario: config init creates repo structure (default terse output)
+    When I run "gitctx config init"
+    Then the exit code should be 0
+    And the output should be exactly "Initialized .gitctx/"
+    And the file ".gitctx/config.yml" should exist
+  ```
+- Verification: `uv run pytest tests/e2e/ -k "config init" --collect-only`
+  (should show 1 test collected)
+```
+
+**Example Bad Step (too vague):**
+```
+**Step 3: Add BDD scenarios**
+- File: cli.feature
+- Action: Edit
+- Content: Add scenarios for config init
+- Verification: Run tests
+```
+
+### 4. Quality Gates Checklist
+
+All of these MUST pass before task is considered complete:
+
+- [ ] **Ruff check**: `uv run ruff check src tests` (exit code 0)
+- [ ] **Ruff format**: `uv run ruff format src tests` (exit code 0)
+- [ ] **Mypy**: `uv run mypy src` (exit code 0)
+- [ ] **Pytest**: `uv run pytest -v` (all tests pass)
+- [ ] **Coverage**: `uv run pytest --cov=src/gitctx --cov-report=term-missing` (≥85%)
+
+### 5. Ticket Update Plan
+
+Specify exact edits to ticket files (use OLD/NEW format):
+
+**Task file** (`{TASK_FILE_PATH}`):
+
+```markdown
+OLD:
+**Status**: 🔵 Not Started
+**Actual Hours**: -
+
+NEW:
+**Status**: 🟡 In Progress
+**Actual Hours**: -
+```
+
+Then after completion:
+
+```markdown
+OLD:
+**Status**: 🟡 In Progress
+**Actual Hours**: -
+
+- [ ] Step 1 description
+- [ ] Step 2 description
+
+NEW:
+**Status**: ✅ Complete
+**Actual Hours**: {actual_hours}
+
+- [x] Step 1 description
+- [x] Step 2 description
+```
+
+**Story README** (`{STORY_README_PATH}`):
+
+Calculate new progress:
+- Current: {current_tasks_complete}/{total_tasks} = {current_percent}%
+- After: {current_tasks_complete + 1}/{total_tasks} = {new_percent}%
+
+```markdown
+OLD:
+**Progress**: ████░░░░░░ {current_percent}% ({current_tasks_complete}/{total_tasks} tasks complete)
+
+NEW:
+**Progress**: {new_progress_bar} {new_percent}% ({current_tasks_complete + 1}/{total_tasks} tasks complete)
+```
+
+Update task table:
+```markdown
+OLD:
+| [TASK-{ID}]({filename}) | {Title} | 🔵 Not Started | {hours} |
+
+NEW:
+| [TASK-{ID}]({filename}) | {Title} | ✅ Complete | {hours} |
+```
+
+**Epic README** (ONLY if this task completes the story):
+
+```markdown
+OLD:
+- [STORY-{STORY_ID}](../STORY-{STORY_ID}/README.md): 🟡 In Progress
+
+NEW:
+- [STORY-{STORY_ID}](../STORY-{STORY_ID}/README.md): ✅ Complete
+```
+
+Update epic progress bar accordingly.
+
+### 6. Commit Message
+
+Use conventional commits format with task ID scope:
+
+```
+feat(TASK-{TASK_ID}): {concise description of what was done}
+
+{optional body explaining "why" this change was made}
+```
+
+Example:
+```
+feat(TASK-0001.1.2.3): Integrate CLI commands with persistent config
+
+Added config init subcommand, updated set/get/list to use UserConfig and
+RepoConfig with proper precedence and type validation.
+```
+
+### 7. Time Estimate Validation
+
+- **Implementation**: {X} hours
+- **Testing**: {Y} hours
+- **Documentation**: {Z} hours
+- **Total**: {W} hours
+
+Compare to task estimate: {task_estimated_hours} hours
+- If within ±0.5 hours: ✓ Estimate validated
+- If exceeds by >0.5 hours: ⚠️  May need scope adjustment or estimate update
+
+### 8. Risk Assessment
+
+**Potential Risks:**
+1. {Risk 1}: {Description}
+   - Mitigation: {How to handle}
+2. {Risk 2}: {Description}
+   - Mitigation: {How to handle}
+
+**Critical Success Factors:**
+- {Factor 1}
+- {Factor 2}
+
+### 9. Pattern Reuse Compliance
+
+**Fixtures Reused:**
+
+- `isolated_env` (tests/unit/conftest.py) - Replaces manual HOME setup
+- `config_factory` (tests/unit/conftest.py) - Generates test config YAML
+- [List all fixtures reused with file location]
+
+**Test Patterns Reused:**
+
+- AAA pattern from tests/unit/core/test_config.py (lines 10-28)
+- Parametrization pattern from [file:lines]
+- [List all patterns with source reference]
+
+**Helpers Reused:**
+
+- `is_windows()` (tests/conftest.py) - Platform detection
+- [List all helpers with source]
+
+**New Patterns Introduced (Justify Each):**
+
+- [Only list if absolutely necessary]
+- [For each: explain why existing patterns insufficient]
+
+**Pattern Reuse Score: X/10**
+
+- 10/10 = 100% reuse, zero duplication
+- 7-9/10 = Mostly reuse, minimal new patterns
+- 4-6/10 = Mixed reuse/new (needs justification)
+- 0-3/10 = Mostly new patterns (SHOULD BE RARE - requires strong justification)
+
+---
+
+**IMPORTANT RULES:**
+
+1. **Be Specific**: No vague terms like "implement X", "handle Y", "add support for Z"
+2. **Exact Paths**: Always use full absolute paths for files
+3. **Exact Changes**: Show OLD/NEW for edits, full content for writes
+4. **Exact Verification**: Provide exact commands with expected output
+5. **Follow Patterns**: Reference existing code patterns from context files
+6. **Respect Workflow**: Strictly follow BDD/TDD principles from CLAUDE.md
+7. **Test First**: If TDD task, tests must be written before implementation
+8. **Scenario First**: If BDD task, scenarios must be written before step definitions
+9. **Pattern Reuse First**: Always use existing fixtures, helpers, and patterns before creating new ones
+10. **Discovery Before Planning**: Read conftest.py files and similar tests BEFORE planning implementation
+11. **Composition Over Creation**: Compose existing fixtures rather than creating new ones
+12. **Reference Sources**: For every pattern used, cite the source file and line numbers
+13. **Justify New Patterns**: Any new fixture/helper requires written justification explaining why existing ones don't work
+14. **Platform Helpers**: Use existing `is_windows()`, `get_platform_*()` helpers, never reimplement
+15. **Fixture Hierarchy**: Respect the 3-level fixture organization (root/unit/e2e conftest.py)
+```
+
+**Agent Configuration:**
+- Type: general-purpose
+- Mode: Research only (creating plan, not executing yet)
+- Output: Detailed implementation plan in markdown
+
+Wait for agent to complete analysis.
+
+---
+
+## Step 6: Present Implementation Plan to User
+
+⚠️ **MANDATORY STOP POINT**
+
+Format and present the agent's plan for approval:
+
+```markdown
+# 📋 Implementation Plan: {TASK_ID}
+
+**Branch**: {BRANCH}
+**Task**: {TASK_ID}: {Title}
+**Story**: {STORY_ID}: {Story Title}
+**Epic**: {EPIC_ID}: {Epic Title}
+**Estimated Hours**: {hours}
+
+═══════════════════════════════════════════════════════════
+
+## Understanding
+
+{agent's understanding section}
+
+═══════════════════════════════════════════════════════════
+
+## BDD/TDD Strategy
+
+{agent's strategy section - identifies which phase}
+
+═══════════════════════════════════════════════════════════
+
+## Implementation Steps
+
+{agent's step-by-step plan with exact files, actions, content, verification}
+
+═══════════════════════════════════════════════════════════
+
+## Quality Gates
+
+{checklist of gates that must pass}
+
+═══════════════════════════════════════════════════════════
+
+## Ticket Updates
+
+{exact OLD/NEW edits for task, story, epic files}
+
+═══════════════════════════════════════════════════════════
+
+## Commit Message
+
+```
+{proposed commit message}
+```
+
+═══════════════════════════════════════════════════════════
+
+## Time Estimate vs Task Estimate
+
+- **Plan estimate**: {W} hours
+- **Task estimate**: {hours} hours
+- **Variance**: {difference} hours ({within/exceeds} estimate)
+
+{if exceeds by >0.5}
+⚠️  Plan exceeds task estimate. Consider:
+- Breaking task into smaller tasks
+- Updating task estimate
+- Removing scope
+{endif}
+
+═══════════════════════════════════════════════════════════
+
+## Risk Assessment
+
+{agent's risk assessment with mitigations}
+
+═══════════════════════════════════════════════════════════
+
+## Approval & Execution
+
+**Do you approve this implementation plan?** (yes/no/modify)
+
+Options:
+- **yes**: Execute implementation (will pause for QA before commit)
+- **no**: Cancel and exit
+- **modify**: Discuss changes to plan (I'll revise and re-present)
+```
+
+**CRITICAL:** Wait for user response. Do NOT proceed until user types "yes".
+
+**If "no"**: Exit cleanly with "Cancelled" message.
+
+**If "modify"**: Ask user what to change, revise plan (possibly re-run agent), re-present. Loop until "yes" or "no".
+
+**If "yes"**: Proceed to Step 7.
+
+---
+
+## Step 7: Execute Implementation
+
+**Only proceed if user approved plan with "yes".**
+
+Launch another Task agent to execute the approved plan:
+
+**Agent Prompt:**
+```markdown
+Execute the approved implementation plan for TASK-{TASK_ID}.
+
+**Approved Plan:**
+
+{Full plan from Step 5 - all sections}
+
+**Your Mission:**
+
+Implement the task following the approved plan exactly.
+
+## Execution Rules
+
+### 1. Follow BDD/TDD Workflow Strictly
+
+**If BDD Phase (writing scenarios):**
+- Write Gherkin scenarios in tests/e2e/features/ FIRST
+- Add step definitions in tests/e2e/steps/ SECOND
+- Run pytest to verify scenarios are recognized: `uv run pytest --collect-only -k "scenario_name"`
+- Scenarios should be recognized but steps may be undefined (that's expected)
+
+**If TDD Phase (writing unit tests):**
+- Write unit tests in tests/unit/ FIRST (RED phase)
+- Tests should FAIL initially (no implementation exists)
+- Run tests to confirm failures: `uv run pytest tests/unit/{module}/ -v`
+- Verify tests fail for the right reason (not import errors)
+
+**If Implementation Phase:**
+- Tests already exist (from previous task)
+- Write minimal code to make tests pass (GREEN phase)
+- Run tests after each function/class: `uv run pytest -v`
+- All tests must pass before proceeding
+
+**If Refactoring Phase:**
+- Tests already exist and are passing
+- Refactor code for quality (REFACTOR phase)
+- Run tests after each change to ensure they stay green
+- No behavior changes, only code quality improvements
+
+### 2. Tool Usage Order
+
+For each step in the plan:
+
+1. **Read before Edit**: Always use Read tool on existing files before Edit
+2. **Verify after Change**: Run the verification command after each step
+3. **Track Progress**: Use TodoWrite to track steps as you complete them
+4. **Stop on Error**: If any verification fails, STOP and report to user
+
+### 3. Progress Tracking
+
+Use TodoWrite to track implementation steps:
+
+```
+[
+  {"content": "Step 1: {description}", "status": "completed", "activeForm": "Completing step 1"},
+  {"content": "Step 2: {description}", "status": "in_progress", "activeForm": "Working on step 2"},
+  {"content": "Step 3: {description}", "status": "pending", "activeForm": "Working on step 3"},
+  ...
+]
+```
+
+Update as you go - mark steps complete one at a time.
+
+### 4. Error Handling
+
+**If a step fails:**
+1. STOP immediately (do not continue to next step)
+2. Show exact error message
+3. Ask user:
+   - **fix**: Attempt automatic fix
+   - **manual**: User will fix manually (exit to terminal)
+   - **skip**: Skip this step (NOT recommended, breaks plan)
+   - **abort**: Cancel entire task
+
+**Common errors:**
+- **Import errors**: Usually means step order is wrong (check plan)
+- **File not found**: Check path is correct (absolute vs relative)
+- **Syntax errors**: Fix before proceeding
+- **Test failures**: Expected in TDD RED phase, unexpected in GREEN/REFACTOR
+
+### 5. Quality First
+
+After implementation is complete:
+- Run ALL quality gates in order
+- Report results for each gate
+- If any gate fails, offer to fix or let user fix manually
+- Do NOT proceed to ticket updates if gates fail
+
+### 6. Communication
+
+For each step:
+- **Starting**: "▶ Step {N}: {description}"
+- **Running**: Show command being run
+- **Output**: Show relevant output (truncate if long)
+- **Result**: "✓ Step {N} complete" or "✗ Step {N} failed"
+
+Keep output concise but informative.
+
+## Output Format
+
+```markdown
+## Executing Implementation Plan
+
+{list all steps from plan with status indicators}
+
+═══════════════════════════════════════════════════════════
+
+## Step 1: {description}
+▶ Starting...
+
+{show what you're doing}
+
+{show command if running one}
+```
+$ {command}
+{output}
+```
+
+✓ Step 1 complete
+
+═══════════════════════════════════════════════════════════
+
+{continue for each step}
+
+═══════════════════════════════════════════════════════════
+
+## Quality Gates
+
+Running all quality gates...
+
+### 1. Ruff Check
+```
+$ uv run ruff check src tests
+{output}
+```
+{✓ Passed or ✗ Failed}
+
+{continue for each gate}
+
+═══════════════════════════════════════════════════════════
+
+{if all passed}
+## ✅ Implementation Complete
+
+All steps executed successfully.
+All quality gates passed.
+
+Proceeding to ticket updates...
+{endif}
+
+{if any failed}
+## ⚠️  Issues Found
+
+{describe issues}
+
+Options:
+- **fix**: Let me attempt automatic fix
+- **manual**: I'll fix manually (exit to terminal)
+- **continue**: Proceed anyway (NOT recommended)
+
+{wait for user input}
+{endif}
+```
+
+## Important Notes
+
+1. **No shortcuts**: Follow the plan exactly, step by step
+2. **Verify everything**: Run verification command after each step
+3. **Tests first**: TDD/BDD means tests before implementation
+4. **Stop on failure**: Don't proceed past errors
+5. **Quality gates**: All must pass before ticket updates
+
+Execute the plan now.
+```
+
+**Agent Configuration:**
+- Type: general-purpose
+- Mode: **Write mode** (full access to make changes)
+- Tools: All (Read, Write, Edit, Bash, TodoWrite)
+
+**Monitor agent execution:**
+- Watch for errors
+- If agent asks for decision (fix/manual/skip/abort), relay to user
+- If agent completes successfully, proceed to Step 8
+- If agent fails, show error and exit
+
+---
+
+## Step 8: Run Quality Gates
+
+After implementation agent finishes, verify all quality gates pass:
+
+**Run each gate in sequence:**
+
+```bash
+# 1. Linting
+uv run ruff check src tests
+
+# 2. Formatting
+uv run ruff format src tests
+
+# 3. Type checking
+uv run mypy src
+
+# 4. Tests
+uv run pytest -v
+
+# 5. Coverage
+uv run pytest --cov=src/gitctx --cov-report=term-missing
+```
+
+**For each gate, check exit code:**
+- Exit code 0: ✓ Passed
+- Exit code ≠ 0: ✗ Failed
+
+**If any gate fails:**
+```markdown
+✗ Quality gate failed: {gate_name}
+
+{error output}
+
+This must be fixed before proceeding.
+
+Options:
+- **fix**: Let me attempt automatic fix
+- **manual**: I'll fix it manually (exit to terminal)
+- **skip**: Continue anyway (NOT recommended - breaks workflow)
+
+Choose: (fix/manual/skip)
+```
+
+Wait for user input.
+
+- If "fix": Attempt to fix (e.g., `uv run ruff check src tests --fix`), then re-run gate
+- If "manual": Exit cleanly with message "Fix issues manually, then re-run /start-next-task"
+- If "skip": Warn strongly but proceed (mark in report that gates were skipped)
+
+**If all gates pass:**
+```markdown
+✅ All Quality Gates Passed
+
+✓ Ruff check: Passed
+✓ Ruff format: Passed
+✓ Mypy: Passed
+✓ Pytest: {pass_count} passed
+✓ Coverage: {coverage}% (threshold: 85%)
+
+Proceeding to ticket updates...
+```
+
+---
+
+## Step 9: Human QA Checkpoint
+
+⚠️ **MANDATORY STOP POINT**
+
+Present summary for human review:
+
+```markdown
+# ✅ Task Implementation Complete: {TASK_ID}
+
+**All quality gates passed! ✨**
+
+═══════════════════════════════════════════════════════════
+
+## Summary
+
+- **Task**: {TASK_ID}: {Title}
+- **Story**: {STORY_ID}
+- **Time**: {actual_hours} hours (estimated: {estimated_hours})
+- **Files Changed**: {count} files
+- **Tests**: All passing ({pass_count} passed)
+- **Coverage**: {coverage}% (threshold: 85%)
+
+═══════════════════════════════════════════════════════════
+
+## Changes Made
+
+### Source Files ({count})
+{list each file with brief description of changes}
+
+### Test Files ({count})
+{list each test file with brief description}
+
+═══════════════════════════════════════════════════════════
+
+## Quality Gate Results
+
+✓ Ruff check: Passed
+✓ Ruff format: Passed
+✓ Mypy: Passed
+✓ Pytest: {pass_count} passed
+✓ Coverage: {coverage}% (target: 85%)
+
+{if any gates were skipped}
+⚠️  Warning: Some gates were skipped at your request:
+{list skipped gates}
+{endif}
+
+═══════════════════════════════════════════════════════════
+
+## Git Status
+
+```
+{run: git status --short}
+```
+
+═══════════════════════════════════════════════════════════
+
+## Diff Summary
+
+```
+{run: git diff --stat}
+```
+
+═══════════════════════════════════════════════════════════
+
+## Ready to Commit
+
+**Commit message:**
+```
+feat(TASK-{TASK_ID}): {description}
+
+{optional body}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+═══════════════════════════════════════════════════════════
+
+## Human QA Required
+
+Please review the changes:
+
+1. **Verify implementation** matches task requirements
+2. **Check tests** cover edge cases and scenarios
+3. **Review diff** for any issues or unintended changes
+
+**Approve for ticket updates and commit?** (yes/no/fix)
+
+Options:
+- **yes**: Update tickets, then commit everything (implementation + tickets)
+- **no**: Discard all changes and exit (git reset --hard)
+- **fix**: Describe issues, I'll fix them before updating tickets
+```
+
+**CRITICAL:** Wait for user response. Do NOT commit until user types "yes".
+
+**If "no":**
+```markdown
+Discarding changes...
+
+Are you sure? This will reset all changes. (yes/no)
+```
+
+If user confirms "yes":
+```bash
+git reset --hard
+git clean -fd
+```
+
+Then exit with "Changes discarded. Task not committed."
+
+**If "fix":**
+Ask user to describe what needs fixing. Either:
+- Make the fixes yourself (if clear instructions)
+- Exit and let user fix manually: "Please fix the issues, then re-run /start-next-task"
+
+**If "yes":** Proceed to Step 10.
+
+---
+
+## Step 10: Update Ticket Files
+
+**Only proceed if user approved with "yes" in Step 9.**
+
+Update ticket files in dependency order (bottom-up):
+
+### 10.1 Update Task File
+
+Use Edit tool to update task file:
+
+**Edit 1: Mark task complete and record hours**
+
+```markdown
+OLD:
+**Status**: 🟡 In Progress
+**Actual Hours**: -
+
+NEW:
+**Status**: ✅ Complete
+**Actual Hours**: {actual_hours}
+```
+
+**Edit 2: Check off implementation steps**
+
+For each step in the task's Implementation Checklist:
+```markdown
+OLD:
+- [ ] Step description
+
+NEW:
+- [x] Step description
+```
+
+Verify edits succeeded.
+
+### 10.2 Update Story README
+
+**Edit 1: Update progress bar and count**
+
+Calculate new progress:
+- Current tasks complete: {N}
+- Total tasks: {M}
+- New count: {N+1}
+- New percentage: {(N+1)/M * 100}%
+- New progress bar: {generate bar with █ and░}
+
+```markdown
+OLD:
+**Progress**: {old_bar} {old_percent}% ({N}/{M} tasks complete)
+
+NEW:
+**Progress**: {new_bar} {new_percent}% ({N+1}/{M} tasks complete)
+```
+
+**Edit 2: Update task table status**
+
+```markdown
+OLD:
+| [TASK-{ID}]({filename}) | {Title} | 🔵 Not Started | {hours} |
+
+NEW:
+| [TASK-{ID}]({filename}) | {Title} | ✅ Complete | {hours} |
+```
+
+### 10.3 Update Epic README (if story now complete)
+
+Check if this was the last task:
+- If {N+1} == {M} (all tasks complete), update epic
+
+**Edit: Update story status in epic**
+
+```markdown
+OLD:
+- [STORY-{STORY_ID}](path/to/story/README.md): 🟡 In Progress
+
+NEW:
+- [STORY-{STORY_ID}](path/to/story/README.md): ✅ Complete
+```
+
+Also update epic progress bar if needed (based on story completion).
+
+### 10.4 Verify All Edits
+
+After all edits:
+```markdown
+✓ Updated ticket files
+
+Files updated:
+- {TASK_FILE}: Status ✅, hours recorded, checklist complete
+- {STORY_README}: Progress {old}% → {new}%, task table updated
+{if epic updated}
+- {EPIC_README}: Story status ✅, epic progress updated
+{endif}
+```
+
+---
+
+## Step 11: Commit Changes
+
+**Only if user approved with "yes" in Step 9.**
+
+**This commits BOTH implementation and updated tickets together (atomic commit).**
+
+### 11.1 Stage All Changes
+
+```bash
+git add -A
+```
+
+Show what's staged (should include implementation + ticket updates):
+```bash
+git diff --cached --stat
+```
+
+### 11.2 Create Commit
+
+Use the commit message from the plan (commits implementation + tickets):
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(TASK-{TASK_ID}): {description}
+
+{optional body}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 11.3 Verify Commit
+
+```bash
+# Show commit
+git log -1 --stat
+
+# Get commit SHA
+git rev-parse HEAD
+```
+
+**Output:**
+```markdown
+✓ Committed: feat(TASK-{TASK_ID}): {description}
+
+Commit: {sha}
+Author: {author}
+Date: {date}
+
+{files changed summary}
+
+View commit: git show {sha}
+```
+
+---
+
+## Step 12: Push to Remote (Optional)
+
+Ask user if they want to push:
+
+```markdown
+═══════════════════════════════════════════════════════════
+
+## Push to Remote?
+
+**Branch**: {branch}
+**Remote**: origin/{branch}
+**Commits ahead of main**: {count}
+**Latest commit**: {sha} - {message}
+
+Push now? (yes/no)
+
+- **yes**: Push to origin/{branch} and optionally monitor CI
+- **no**: Commit stays local (push manually later with: git push)
+```
+
+Wait for user input.
+
+**If "yes":**
+
+```bash
+# Push with upstream tracking
+git push -u origin {branch}
+```
+
+Show result:
+```markdown
+✓ Pushed to origin/{branch}
+
+Remote: {remote_url}
+Branch: {branch}
+Commit: {sha}
+```
+
+**If CI is configured (has GitHub Actions):**
+```markdown
+Monitor CI? (yes/no)
+
+- **yes**: Watch CI run (blocks until complete)
+- **no**: Continue (check CI later with: gh run list)
+```
+
+If user says "yes":
+```bash
+# Get latest run
+gh run list --limit 1
+
+# Watch it
+gh run watch {run_id}
+```
+
+**If "no":**
+```markdown
+✓ Commit stays local
+
+Push later with: git push
+```
+
+---
+
+## Step 13: Final Report
+
+Print comprehensive summary:
+
+```markdown
+# ✨ Task Complete: {TASK_ID}
+
+**Status**: {Committed and pushed / Committed (not pushed)}
+**Time**: {actual_hours} hours (estimated: {estimated_hours})
+**Commit**: {sha}
+{if pushed}
+**Remote**: origin/{branch}
+{endif}
+
+═══════════════════════════════════════════════════════════
+
+## What Was Done
+
+**Task**: {TASK_ID}: {Title}
+
+**Changes**:
+- {summary of changes}
+- {quality metrics}
+
+**Ticket Updates**:
+- Task status: 🔵 → ✅
+- Story progress: {old}% → {new}%
+{if epic updated}
+- Epic progress: {epic_old}% → {epic_new}%
+{endif}
+
+═══════════════════════════════════════════════════════════
+
+## Next Steps
+
+{if more pending tasks in story}
+### Continue Story
+
+**Next task**: {NEXT_TASK_ID}: {Next Task Title}
+
+Run: `/start-next-task`
+
+{else if story complete}
+### Story Complete! 🎉
+
+All {M} tasks in {STORY_ID} are complete.
+
+**Create Pull Request:**
+
+1. {if not pushed}Push branch:
+   ```
+   git push -u origin {branch}
+   ```
+
+2. {endif}Create PR:
+   ```
+   gh pr create --title "{STORY_ID}: {story title}" \\
+     --body "$(cat docs/tickets/{INIT}/{EPIC}/{STORY}/README.md)"
+   ```
+
+3. Fix GitHub links in PR body:
+   - Replace relative paths with blob URLs
+   - Format: `https://github.com/{org}/{repo}/blob/{branch}/{path}`
+
+4. Monitor CI:
+   ```
+   gh run watch
+   ```
+
+5. Request review when CI passes
+
+**Or run final validation:**
+```
+/review-story
+```
+{endif}
+
+{if pushed and CI exists}
+### Monitor CI
+
+**Status**: `gh run list --limit 1`
+**Watch**: `gh run watch {run_id}`
+**Checks**: `gh pr checks` {if PR exists}
+{endif}
+
+═══════════════════════════════════════════════════════════
+
+**Task completed successfully! 🎉**
+```
+
+**Exit successfully.**
+
+---
+
+## Error Recovery
+
+### Error: Not on Story Branch
+
+```markdown
+✗ Not on a story branch
+
+Current branch: {branch}
+
+You must be on a STORY-* branch to use this command.
+
+**Options:**
+
+1. Switch to existing story branch:
+   ```
+   git checkout STORY-XXXX
+   ```
+
+2. Create new story branch:
+   ```
+   git checkout -b STORY-XXXX
+   ```
+
+3. List available story branches:
+   ```
+   git branch | grep STORY-
+   ```
+```
+
+Exit with error.
+
+### Error: No Pending Tasks
+
+```markdown
+✓ All tasks complete!
+
+Story: {STORY_ID} (100% complete)
+
+**Next steps:**
+
+1. Run `/review-story` for final validation
+2. Create PR: `gh pr create`
+```
+
+Exit successfully.
+
+### Error: Prerequisites Not Met
+
+```markdown
+✗ Prerequisites not met for {TASK_ID}
+
+**Required:**
+
+{for each failed prerequisite}
+  ✗ {PREREQUISITE}: {current_status} (expected: ✅ Complete)
+{endfor}
+
+**Passed:**
+
+{for each passed prerequisite}
+  ✓ {PREREQUISITE}: {status}
+{endfor}
+
+Complete prerequisites first, then retry `/start-next-task`.
+```
+
+Exit with error.
+
+### Error: Quality Gate Failed (User Declined Fix)
+
+```markdown
+✗ Quality gate failed: {gate_name}
+
+{error_output}
+
+**You chose to exit and fix manually.**
+
+After fixing, re-run: `/start-next-task`
+
+Note: The task status is 🟡 In Progress. The command will detect this
+and offer to continue from where it left off.
+```
+
+Exit cleanly.
+
+### Error: User Declined Commit
+
+```markdown
+✗ Commit declined
+
+You chose not to commit the changes.
+
+**Changes are still in working directory.**
+
+Options:
+1. Review changes: `git diff`
+2. Commit manually: `git commit -am "message"`
+3. Discard changes: `git reset --hard`
+4. Re-run `/start-next-task` to try again
+```
+
+Exit cleanly (don't discard changes automatically).
+
+---
+
+## Implementation Notes
+
+### Agent Coordination
+
+1. **Agent 1 (Planning)**:
+   - Type: general-purpose
+   - Mode: Research (read-only)
+   - Output: Implementation plan
+   - Runs in Step 5
+
+2. **Agent 2 (Execution)**:
+   - Type: general-purpose
+   - Mode: Write (full access)
+   - Input: Approved plan from Agent 1
+   - Output: Implementation results
+   - Runs in Step 7
+
+### State Tracking
+
+- Task status transitions: 🔵 → 🟡 (start) → ✅ (complete)
+- Track actual hours vs estimate
+- Update parent story/epic automatically when needed
+- Maintain progress bars with accurate percentages
+
+### TodoWrite Integration
+
+- Create todos at start of execution (Step 7)
+- Update as each step completes
+- Clear todos at end of task
+- Format: `[{"content": "...", "status": "...", "activeForm": "..."}]`
+
+### Quality Enforcement
+
+- ALL gates must pass (or user explicitly skips)
+- No commits with failing tests
+- Coverage threshold enforced (≥85%)
+- Report which gates passed/failed clearly
+
+### Git Hygiene
+
+- One task = one commit (atomic)
+- Proper format: `feat(TASK-ID): description`
+- Co-authored-by Claude footer
+- Optional push to remote with CI monitoring
+
+---
+
+## Success Criteria
+
+- ✅ Validates story branch before starting
+- ✅ Loads complete story context (story, tasks, epic, init, roadmap, CLAUDE.md)
+- ✅ Identifies correct next pending task
+- ✅ Validates all prerequisites before proceeding
+- ✅ Creates detailed implementation plan via Task agent
+- ✅ Presents plan for approval (REQUIRED)
+- ✅ Executes plan via separate Task agent (only after approval)
+- ✅ Follows strict BDD/TDD workflow (test-first)
+- ✅ Runs all quality gates (must pass)
+- ✅ Updates task/story/epic files correctly (in dependency order)
+- ✅ Requires human QA before commit (REQUIRED)
+- ✅ Creates properly formatted commit
+- ✅ Optionally pushes to remote with CI monitoring
+- ✅ One task = one commit (atomic)
+- ✅ Handles errors gracefully with clear recovery steps
+- ✅ Provides clear next steps after completion
+
+---
+
+## Begin Execution
+
+Follow the workflow steps 1-13 in order. Stop at approval gates and wait for user input. Handle errors gracefully. Report progress clearly.
+
+**Start with Step 1: Verify Story Branch**

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # Claude settings
 .claude/settings.local.json
 
-# NOTE: .gitctx/ will be handled later in development
+# gitctx - NEVER run gitctx from the repo root (use temp test environments)
+.gitctx/
 
 # direnv
 .envrc.local
@@ -32,6 +33,7 @@ ENV/
 .coverage
 .coverage.*
 coverage.xml
+coverage.json
 htmlcov/
 .tox/
 .nox/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,797 @@
+# gitctx Configuration Guide
+
+**Complete reference for configuring gitctx, including all options, environment variables, security best practices, and troubleshooting.**
+
+---
+
+## Overview
+
+gitctx uses a **two-file configuration system** that separates secrets from team settings:
+
+- **User Config** (`~/.gitctx/config.yml`) - API keys only, never committed to git
+- **Repo Config** (`.gitctx/config.yml`) - Team settings, safe to commit and share
+
+This design ensures API keys stay secure while allowing teams to share search parameters, indexing settings, and model preferences.
+
+---
+
+## Quick Start
+
+```bash
+# 1. Initialize repo configuration (creates .gitctx/)
+gitctx config init
+
+# 2. Set your API key (stored in ~/.gitctx/config.yml)
+gitctx config set api_keys.openai sk-abc123...
+
+# 3. Optional: Customize team settings (stored in .gitctx/config.yml)
+gitctx config set search.limit 20
+gitctx config set index.chunk_size 1500
+
+# 4. Verify configuration
+gitctx config list
+```
+
+---
+
+## Configuration Files
+
+### User Config (~/.gitctx/config.yml)
+
+**Purpose**: Stores API keys and user-specific preferences
+
+**Location**:
+- **macOS/Linux**: `~/.gitctx/config.yml`
+- **Windows**: `%USERPROFILE%\.gitctx\config.yml`
+
+**Security**:
+- File permissions: `0600` (owner read/write only)
+- Never committed to git (excluded by design)
+- API keys auto-masked in all output (shows `sk-...123`)
+
+**Example**:
+```yaml
+api_keys:
+  openai: sk-abc123def456ghi789jkl...
+```
+
+**Precedence** (highest to lowest):
+1. `OPENAI_API_KEY` environment variable
+2. User YAML file (`~/.gitctx/config.yml`)
+3. Default (none)
+
+### Repo Config (.gitctx/config.yml)
+
+**Purpose**: Stores team settings for search, indexing, and models
+
+**Location**: `.gitctx/config.yml` (in repo root)
+
+**Security**:
+- File permissions: `0644` (readable by all, writable by owner)
+- **Safe to commit** - contains no secrets
+- Shared across team via git
+
+**Example**:
+```yaml
+search:
+  limit: 10
+  rerank: true
+
+index:
+  chunk_size: 1000
+  chunk_overlap: 200
+
+model:
+  embedding: text-embedding-3-large
+```
+
+**Precedence** (highest to lowest):
+1. `GITCTX_*` environment variables (e.g., `GITCTX_SEARCH__LIMIT`)
+2. Repo YAML file (`.gitctx/config.yml`)
+3. Defaults
+
+---
+
+## Configuration Options
+
+### API Keys
+
+#### `api_keys.openai`
+- **Type**: String (SecretStr - auto-masked)
+- **Required**: Yes (for indexing)
+- **Storage**: User config only (~/.gitctx/config.yml)
+- **Default**: None
+- **Description**: OpenAI API key for generating embeddings
+- **Example**: `sk-abc123def456...`
+
+**How to set**:
+```bash
+# Via config command (recommended)
+gitctx config set api_keys.openai sk-abc123...
+
+# Via environment variable
+export OPENAI_API_KEY=sk-abc123...
+
+# Verify (shows masked value)
+gitctx config get api_keys.openai
+# Output: sk-...123
+```
+
+**Security Notes**:
+- Never commit API keys to git
+- Keys are automatically masked in all output
+- File permissions enforced to 0600
+- Rotate keys if exposed
+
+### Search Settings
+
+#### `search.limit`
+- **Type**: Integer
+- **Range**: 1-100
+- **Default**: 10
+- **Description**: Maximum number of search results to return
+- **Example**: `20`
+
+```bash
+gitctx config set search.limit 20
+```
+
+#### `search.rerank`
+- **Type**: Boolean
+- **Default**: `true`
+- **Description**: Enable reranking of search results for better relevance
+- **Example**: `false`
+
+```bash
+gitctx config set search.rerank false
+```
+
+### Index Settings
+
+#### `index.chunk_size`
+- **Type**: Integer
+- **Range**: >0
+- **Default**: 1000
+- **Description**: Token chunk size for splitting code into embeddings
+- **Example**: `1500`
+
+```bash
+gitctx config set index.chunk_size 1500
+```
+
+**Guidance**:
+- Smaller chunks (500-1000): Better precision, more API calls
+- Larger chunks (1000-2000): Better context, fewer API calls
+- Recommended: 1000 for balanced performance
+
+#### `index.chunk_overlap`
+- **Type**: Integer
+- **Range**: ≥0
+- **Default**: 200
+- **Description**: Token overlap between consecutive chunks to preserve context
+- **Example**: `100`
+
+```bash
+gitctx config set index.chunk_overlap 100
+```
+
+**Guidance**:
+- Overlap prevents context loss at chunk boundaries
+- Typical range: 10-20% of chunk_size
+- Zero overlap risks missing cross-boundary context
+
+### Model Settings
+
+#### `model.embedding`
+- **Type**: String
+- **Default**: `text-embedding-3-large`
+- **Description**: OpenAI embedding model to use for code embeddings
+- **Example**: `text-embedding-3-small`
+
+```bash
+gitctx config set model.embedding text-embedding-3-small
+```
+
+**Available models**:
+- `text-embedding-3-large` (default) - Best quality, higher cost
+- `text-embedding-3-small` - Good quality, lower cost
+
+---
+
+## Environment Variables
+
+Environment variables override config file values, useful for CI/CD and temporary overrides.
+
+### User Config Variables
+
+| Variable | Config Key | Description | Example |
+|----------|-----------|-------------|---------|
+| `OPENAI_API_KEY` | `api_keys.openai` | OpenAI API key | `sk-abc123...` |
+
+**Precedence**: `OPENAI_API_KEY` > User YAML file
+
+**Usage**:
+```bash
+# Set for current session
+export OPENAI_API_KEY=sk-abc123...
+
+# Or prefix command
+OPENAI_API_KEY=sk-abc123... gitctx index
+```
+
+### Repo Config Variables
+
+| Variable | Config Key | Description | Example |
+|----------|-----------|-------------|---------|
+| `GITCTX_SEARCH__LIMIT` | `search.limit` | Max search results | `20` |
+| `GITCTX_SEARCH__RERANK` | `search.rerank` | Enable reranking | `false` |
+| `GITCTX_INDEX__CHUNK_SIZE` | `index.chunk_size` | Token chunk size | `1500` |
+| `GITCTX_INDEX__CHUNK_OVERLAP` | `index.chunk_overlap` | Chunk overlap | `100` |
+| `GITCTX_MODEL__EMBEDDING` | `model.embedding` | Embedding model | `text-embedding-3-small` |
+
+**Naming Convention**:
+- Prefix: `GITCTX_`
+- Section separator: `__` (double underscore)
+- Format: `GITCTX_<SECTION>__<FIELD>`
+
+**Precedence**: `GITCTX_*` env vars > Repo YAML file
+
+**Usage**:
+```bash
+# Override search limit for CI
+export GITCTX_SEARCH__LIMIT=50
+
+# Use smaller embedding model to save costs
+export GITCTX_MODEL__EMBEDDING=text-embedding-3-small
+```
+
+---
+
+## Command Reference
+
+### `gitctx config init`
+
+Initialize `.gitctx/` directory structure in the current repository.
+
+**Creates**:
+- `.gitctx/config.yml` - Repo config with default settings
+- `.gitctx/.gitignore` - Excludes `db/`, `logs/`, `*.log`
+
+**Example**:
+```bash
+$ gitctx config init
+Initialized .gitctx/
+```
+
+**Idempotent**: Safe to run multiple times (won't overwrite existing config)
+
+### `gitctx config set <key> <value>`
+
+Set a configuration value (routes to user or repo config automatically).
+
+**Routing**:
+- `api_keys.*` → User config (~/.gitctx/config.yml)
+- `search.*`, `index.*`, `model.*` → Repo config (.gitctx/config.yml)
+
+**Examples**:
+```bash
+# Set API key (user config)
+gitctx config set api_keys.openai sk-abc123...
+
+# Set search limit (repo config)
+gitctx config set search.limit 20
+
+# Set chunk size (repo config)
+gitctx config set index.chunk_size 1500
+```
+
+**Type Validation**: Values are validated against expected types (int, bool, string)
+
+### `gitctx config get <key>`
+
+Get a configuration value (shows masked secrets).
+
+**Default Mode** (terse):
+```bash
+$ gitctx config get api_keys.openai
+sk-...123
+```
+
+**Verbose Mode** (shows source):
+```bash
+$ gitctx config get api_keys.openai --verbose
+api_keys.openai = sk-...123 (from OPENAI_API_KEY)
+```
+
+**Source Indicators**:
+- `(from OPENAI_API_KEY)` - Environment variable
+- `(from user config)` - ~/.gitctx/config.yml
+- `(from GITCTX_SEARCH__LIMIT)` - Environment variable
+- `(from repo config)` - .gitctx/config.yml
+- `(default)` - Built-in default value
+
+### `gitctx config list`
+
+List all configuration values.
+
+**Default Mode** (terse, hides default sources):
+```bash
+$ gitctx config list
+api_keys.openai=sk-...123 (from user config)
+search.limit=20 (from repo config)
+search.rerank=true
+index.chunk_size=1000
+index.chunk_overlap=200
+model.embedding=text-embedding-3-large
+```
+
+**Verbose Mode** (shows all sources including defaults):
+```bash
+$ gitctx config list --verbose
+api_keys.openai=sk-...123 (from user config)
+search.limit=20 (from repo config)
+search.rerank=true (default)
+index.chunk_size=1000 (default)
+index.chunk_overlap=200 (default)
+model.embedding=text-embedding-3-large (default)
+```
+
+**Quiet Mode** (machine-parseable):
+```bash
+$ gitctx config list --quiet
+api_keys.openai=sk-...123
+search.limit=20
+search.rerank=true
+index.chunk_size=1000
+index.chunk_overlap=200
+model.embedding=text-embedding-3-large
+```
+
+---
+
+## Security Best Practices
+
+### API Key Safety
+
+#### 1. Never Commit API Keys
+- User config (~/.gitctx/config.yml) is never committed by design
+- Repo config (.gitctx/config.yml) cannot store API keys (enforced by Pydantic models)
+- If you accidentally commit a key, **rotate it immediately** at https://platform.openai.com/api-keys
+
+#### 2. Use Environment Variables in CI/CD
+```bash
+# GitHub Actions
+- name: Index repository
+  env:
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  run: gitctx index
+```
+
+#### 3. Check File Permissions
+```bash
+# Verify user config has secure permissions
+ls -la ~/.gitctx/config.yml
+# Should show: -rw------- (0600)
+
+# Fix if needed
+chmod 600 ~/.gitctx/config.yml
+```
+
+#### 4. Rotate Keys Regularly
+- Rotate keys every 90 days as a best practice
+- Rotate immediately if:
+  - Key appears in logs or error messages
+  - Key was committed to git (even if reverted)
+  - Team member with access leaves
+
+### File Permissions
+
+**User Config** (`~/.gitctx/config.yml`):
+- **Permissions**: `0600` (owner read/write only)
+- **Enforced**: gitctx automatically sets 0600 on save
+- **Warning**: gitctx warns if permissions are too open (e.g., 0644)
+
+**Repo Config** (`.gitctx/config.yml`):
+- **Permissions**: `0644` (readable by all, writable by owner)
+- **Safe to commit**: Contains no secrets
+- **Shareable**: Team members can read and apply settings
+
+### Secret Masking
+
+All API keys are automatically masked in output:
+
+```bash
+$ gitctx config get api_keys.openai
+sk-...123  # Shows first 3 and last 3 chars
+
+$ gitctx config list
+api_keys.openai=sk-...123 (from user config)
+```
+
+**Masking Format**:
+- Keys >6 chars: Shows first 3 and last 3 (e.g., `sk-...123`)
+- Keys ≤6 chars: Shows `***`
+
+---
+
+## Cross-Platform Notes
+
+### Windows
+
+**User Config Location**:
+```
+%USERPROFILE%\.gitctx\config.yml
+```
+
+**File Permissions**:
+- Windows uses ACLs (Access Control Lists), not Unix permissions
+- gitctx verifies file is readable/writable by owner
+- No direct equivalent to Unix `0600` permissions
+
+**Path Handling**:
+- Backslashes (`\`) used for paths
+- `%USERPROFILE%` expands to `C:\Users\YourName`
+
+**Terminal Support**:
+- **Windows Terminal**: Full Unicode support (✓ ✗ ⚠️ symbols)
+- **PowerShell 7+**: Full Unicode support
+- **cmd.exe (legacy)**: ASCII fallback ([OK] [X] [!] symbols)
+
+**Example Setup**:
+```powershell
+# PowerShell
+gitctx config init
+gitctx config set api_keys.openai sk-abc123...
+```
+
+### macOS / Linux
+
+**User Config Location**:
+```
+~/.gitctx/config.yml
+```
+
+**File Permissions**:
+- Standard Unix permissions (0600/0644)
+- gitctx enforces 0600 for user config
+- Warns if permissions are too open
+
+**Path Handling**:
+- Forward slashes (`/`) for paths
+- `~` expands to user home directory
+- HOME environment variable respected
+
+**Terminal Support**:
+- Full Unicode support in modern terminals
+- Symbols: ✓ ✗ ⚠️ 💡 →
+
+**Example Setup**:
+```bash
+# Bash/Zsh
+gitctx config init
+gitctx config set api_keys.openai sk-abc123...
+```
+
+---
+
+## Troubleshooting
+
+### "Permission denied" when saving config
+
+**Problem**: Cannot write to config file due to insufficient permissions.
+
+**Symptoms**:
+```bash
+$ gitctx config set api_keys.openai sk-abc123...
+✗ Error: permission denied: ~/.gitctx/config.yml
+```
+
+**Solutions**:
+
+1. **Check file permissions**:
+```bash
+ls -la ~/.gitctx/config.yml
+# Should show: -rw------- (owner read/write)
+```
+
+2. **Fix permissions**:
+```bash
+chmod 600 ~/.gitctx/config.yml
+```
+
+3. **Check directory permissions**:
+```bash
+ls -ld ~/.gitctx
+# Should be readable/writable by owner
+chmod 700 ~/.gitctx
+```
+
+4. **On Windows**: Verify file is not read-only
+```powershell
+attrib ~/.gitctx/config.yml
+# Remove read-only if set
+attrib -r ~/.gitctx/config.yml
+```
+
+### "Invalid value" validation error
+
+**Problem**: Config value doesn't match expected type or range.
+
+**Symptoms**:
+```bash
+$ gitctx config set search.limit abc
+✗ Error: invalid value for search.limit
+
+Expected: integer (1-100)
+Got:      "abc"
+```
+
+**Solutions**:
+
+1. **Check type constraints**:
+   - `search.limit`: Integer (1-100)
+   - `search.rerank`: Boolean (true/false)
+   - `index.chunk_size`: Integer (>0)
+   - `index.chunk_overlap`: Integer (≥0)
+
+2. **Use correct format**:
+```bash
+# Good
+gitctx config set search.limit 20
+gitctx config set search.rerank true
+
+# Bad
+gitctx config set search.limit "twenty"  # Not an integer
+gitctx config set search.limit 200       # Exceeds max (100)
+```
+
+3. **Check range constraints**:
+```bash
+# search.limit must be 1-100
+gitctx config set search.limit 50  # ✓ Valid
+
+# index.chunk_size must be >0
+gitctx config set index.chunk_size 1000  # ✓ Valid
+gitctx config set index.chunk_size 0     # ✗ Invalid
+```
+
+### "Config file not found"
+
+**Problem**: Config file doesn't exist yet.
+
+**Symptoms**:
+```bash
+$ gitctx config get search.limit
+✗ Error: no index found
+```
+
+**Solution**:
+```bash
+# Initialize .gitctx/ directory
+gitctx config init
+```
+
+### API key not recognized
+
+**Problem**: API key is set but not being loaded correctly.
+
+**Symptoms**:
+```bash
+$ gitctx index
+✗ Error: OPENAI_API_KEY not set
+```
+
+**Diagnostic Steps**:
+
+1. **Verify file exists**:
+```bash
+ls ~/.gitctx/config.yml
+# Should exist
+```
+
+2. **Check file contents**:
+```bash
+cat ~/.gitctx/config.yml
+# Should contain:
+# api_keys:
+#   openai: sk-...
+```
+
+3. **Verify permissions** (Unix only):
+```bash
+ls -la ~/.gitctx/config.yml
+# Should show: -rw------- (0600)
+```
+
+4. **Test with environment variable**:
+```bash
+export OPENAI_API_KEY=sk-abc123...
+gitctx config get api_keys.openai
+# Should show: sk-...123
+```
+
+5. **Check config loading**:
+```bash
+gitctx config list --verbose
+# Should show: api_keys.openai=sk-...123 (from user config)
+```
+
+### "Insecure permissions" warning
+
+**Problem**: User config file has permissions that are too open.
+
+**Symptoms**:
+```
+Warning: User config has insecure permissions (current: 644, should be 0600)
+```
+
+**Solution**:
+```bash
+chmod 600 ~/.gitctx/config.yml
+```
+
+**Explanation**: User config should only be readable by owner (you) since it contains API keys.
+
+### YAML parsing errors
+
+**Problem**: Config file contains invalid YAML syntax.
+
+**Symptoms**:
+```bash
+✗ Error: Failed to parse config file
+```
+
+**Solutions**:
+
+1. **Check YAML syntax**:
+```bash
+# Valid YAML
+search:
+  limit: 20
+
+# Invalid YAML (wrong indentation)
+search:
+limit: 20
+```
+
+2. **Validate YAML online**: Use https://www.yamllint.com/
+
+3. **Recreate config**:
+```bash
+# Backup old config
+mv ~/.gitctx/config.yml ~/.gitctx/config.yml.bak
+
+# Create fresh config
+gitctx config set api_keys.openai sk-abc123...
+```
+
+---
+
+## Examples
+
+### Basic Setup
+
+```bash
+# 1. Initialize repo config
+cd /path/to/your/repo
+gitctx config init
+
+# 2. Set API key (stored in ~/.gitctx/config.yml)
+gitctx config set api_keys.openai sk-abc123def456...
+
+# 3. Verify configuration
+gitctx config list
+
+# 4. Index repository
+gitctx index
+
+# 5. Search
+gitctx search "authentication logic"
+```
+
+### Team Configuration
+
+**Scenario**: Share search and indexing preferences across team.
+
+**Steps**:
+
+1. **One team member sets up**:
+```bash
+gitctx config init
+
+# Customize settings
+gitctx config set search.limit 25
+gitctx config set index.chunk_size 1500
+gitctx config set index.chunk_overlap 150
+
+# Commit .gitctx/ to git
+git add .gitctx/
+git commit -m "chore: Add gitctx team configuration"
+git push
+```
+
+2. **Other team members clone**:
+```bash
+git pull
+
+# Settings automatically loaded from .gitctx/config.yml
+gitctx config list
+# Shows team settings:
+# search.limit=25 (from repo config)
+# index.chunk_size=1500 (from repo config)
+
+# Each member sets their own API key
+gitctx config set api_keys.openai sk-their-key...
+```
+
+### Environment Variable Overrides
+
+**Scenario**: Use different settings for CI/CD vs local development.
+
+**Local Development** (uses repo config):
+```bash
+# .gitctx/config.yml has:
+# search:
+#   limit: 10
+
+gitctx search "query"
+# Returns 10 results
+```
+
+**CI/CD** (overrides with env var):
+```bash
+# GitHub Actions workflow
+- name: Search codebase
+  env:
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    GITCTX_SEARCH__LIMIT: 50  # Override for CI
+  run: |
+    gitctx index
+    gitctx search "TODO FIXME" --limit 50
+```
+
+### Temporary Setting Override
+
+```bash
+# Override for single command
+GITCTX_SEARCH__LIMIT=100 gitctx search "authentication"
+
+# Override for session
+export GITCTX_SEARCH__LIMIT=100
+gitctx search "auth"      # Uses 100
+gitctx search "database"  # Uses 100
+
+# Restore default
+unset GITCTX_SEARCH__LIMIT
+```
+
+### Cost Optimization
+
+**Scenario**: Reduce OpenAI API costs by using smaller embedding model.
+
+```bash
+# Use smaller, cheaper embedding model
+gitctx config set model.embedding text-embedding-3-small
+
+# Use larger chunk size (fewer API calls)
+gitctx config set index.chunk_size 2000
+
+# Reindex with new settings
+gitctx index --force
+```
+
+**Cost Comparison**:
+- `text-embedding-3-large`: Higher quality, ~2x cost
+- `text-embedding-3-small`: Good quality, ~50% cost savings
+
+---
+
+## Related Documentation
+
+- [Main README](../README.md) - Getting started guide
+- [TUI Guide](../TUI_GUIDE.md) - CLI output formats and symbols
+- [Architecture Docs](architecture/) - Technical design details
+
+---
+
+**Last Updated**: 2025-10-05

--- a/docs/tickets/INIT-0001/EPIC-0001.1/README.md
+++ b/docs/tickets/INIT-0001/EPIC-0001.1/README.md
@@ -1,9 +1,9 @@
 # EPIC-0001.1: CLI Foundation
 
 **Parent Initiative**: [INIT-0001](../README.md)
-**Status**: 🟡 In Progress
-**Estimated**: 8 story points
-**Progress**: ████████░░ 80% (8/10 story points estimated, 2 stories remaining)
+**Status**: ✅ Complete
+**Estimated**: 10 story points
+**Progress**: ██████████ 100% (10/10 story points - all stories complete)
 
 ## Overview
 
@@ -23,9 +23,9 @@ Build the complete command-line interface with all commands working against mock
 |----|-------|--------|--------|
 | [STORY-0001.1.0](STORY-0001.1.0/README.md) | Development Environment Setup | ✅ Complete | 5 |
 | [STORY-0001.1.1](STORY-0001.1.1/README.md) | CLI Framework Setup | ✅ Complete | 3 |
-| STORY-0001.1.2 | (TBD - Next story) | 🔵 Not Started | TBD |
+| [STORY-0001.1.2](STORY-0001.1.2/README.md) | Real Configuration Management | ✅ Complete | 5 |
 
-**Note**: STORY-0001.1.1 included all CLI commands (index, search, config, clear) as tasks within a single story, as they are tightly coupled for the CLI interface contract.
+**Note**: STORY-0001.1.1 implemented all CLI commands with mock/in-memory configuration. STORY-0001.1.2 replaces the mock config with real Pydantic Settings-based persistent configuration.
 
 ## BDD Specifications
 
@@ -78,20 +78,31 @@ def clear(
 
 ### Configuration Management
 
+**STORY-0001.1.1**: Mock implementation (in-memory dict)
 ```python
-# src/gitctx/cli/config.py
-class Config:
-    def __init__(self):
-        self.path = Path.home() / ".gitctx" / "config.yml"
-    
-    def set(self, key: str, value: str):
-        """Set a config value using dot notation."""
-    
-    def get(self, key: str) -> str:
-        """Get a config value, checking env vars first."""
-    
-    def list(self) -> list[str]:
-        """Get all config values, checking env vars first."""
+# src/gitctx/cli/config.py (mock)
+_config_store: dict[str, Any] = {}  # In-memory for testing
+```
+
+**STORY-0001.1.2**: Real implementation (Pydantic Settings)
+```python
+# src/gitctx/core/config.py
+from pydantic_settings import BaseSettings
+
+class GitCtxSettings(BaseSettings):
+    """Type-safe configuration with multi-source loading.
+
+    Precedence: OPENAI_API_KEY > GITCTX_* env vars > YAML > defaults
+    """
+    api_keys: ApiKeys
+    search: SearchSettings
+    index: IndexSettings
+    model: ModelSettings
+
+    model_config = SettingsConfigDict(
+        yaml_file="~/.gitctx/config.yml",
+        env_prefix="GITCTX_",
+    )
 ```
 
 ## Dependencies
@@ -99,6 +110,8 @@ class Config:
 - `typer[all]` - CLI framework with completion
 - `rich` - Terminal formatting and progress bars
 - `pyyaml` - Configuration file management
+- `pydantic>=2.11.0` - Type validation (STORY-0001.1.2)
+- `pydantic-settings[yaml]>=2.11.0` - Config management (STORY-0001.1.2)
 
 ## Success Criteria
 
@@ -142,9 +155,17 @@ class Config:
 - ✅ Config "unset" via blank values (cleaner than separate command)
 - ✅ Zero critical/major issues found in code review
 
-**Total Progress**: 8/10 points estimated (80%)
+**STORY-0001.1.2: Real Configuration Management** (2 points) - **Not Started**
+- 🔵 Pydantic Settings-based configuration
+- 🔵 Three-tier precedence: `OPENAI_API_KEY` > `GITCTX_*` > YAML
+- 🔵 Type validation and SecretStr masking
+- 🔵 Persistent storage at `~/.gitctx/config.yml`
+- 🔵 Source indicators in output
+- 🔵 Backward compatible with STORY-0001.1.1 CLI interface
+
+**Total Progress**: 8/10 points complete (80%) - STORY-0001.1.2 in progress with 5 polish tasks remaining
 
 ---
 
 **Created**: 2025-09-28
-**Last Updated**: 2025-10-04
+**Last Updated**: 2025-10-05

--- a/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/README.md
+++ b/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/README.md
@@ -1,0 +1,677 @@
+# STORY-0001.1.2: Real Configuration Management
+
+**Parent Epic**: [EPIC-0001.1](../README.md)
+**Status**: ✅ Complete
+**Story Points**: 5 (was 2, +1 for TUI, +1 for PR review, +1 for performance/docs/polish)
+**Progress**: ██████████ 100% (10/10 tasks complete, 7.75/7.25 hours actual)
+
+## User Story
+
+As a **developer**
+I want **persistent configuration with user and repo separation**
+So that **my API keys stay secure in my home directory while team settings are shared in the repo, with my existing OPENAI_API_KEY automatically recognized**
+
+## Acceptance Criteria
+
+- [x] Config uses Pydantic Settings for type-safe validation
+- [x] **User config** (`~/.gitctx/config.yml`) stores API keys only with file permissions 0600
+- [x] **Repo config** (`.gitctx/config.yml`) stores team settings only (search, index, model) with file permissions 0644
+- [x] NEW `config init` subcommand creates repo structure:
+  - Creates `.gitctx/config.yml` with defaults
+  - Creates `.gitctx/.gitignore` to exclude `db/`, `logs/`, `*.log`
+- [x] User config precedence (API keys only):
+  1. Provider standard env var (`OPENAI_API_KEY`)
+  2. User YAML file (`~/.gitctx/config.yml`)
+- [x] Repo config precedence (team settings only):
+  1. gitctx-prefixed env var (`GITCTX_SEARCH__LIMIT`)
+  2. Repo YAML file (`.gitctx/config.yml`)
+- [x] Type validation prevents invalid configurations (e.g., `search.limit` must be int)
+- [x] API keys auto-masked using SecretStr
+- [x] CLI automatically routes config by key pattern (api_keys.* → user, else → repo)
+- [x] **TUI: Progressive disclosure** - All config commands support `-v/--verbose` and `-q/--quiet` flags
+- [x] **TUI: Default mode is terse** - `config init` shows single line, `config get` shows value only (git-like)
+- [x] **TUI: Verbose mode shows details** - `config get --verbose` shows key and source, `config list --verbose` shows all sources
+- [x] **TUI: Quiet mode suppresses output** - All commands support `--quiet` for scripting
+- [x] **TUI: Platform-aware symbols** - Use ✓/✗/⚠️/💡 on modern terminals, [OK]/[X]/[!]/[i] on Windows cmd.exe
+- [x] **TUI: First-run tips** - Show tip box once for config command, then hide forever
+- [x] **TUI: Standard exit codes** - Exit code 2 for usage errors, 6 for permission denied, 1 for general errors
+- [x] `config get` default shows value only (terse), `--verbose` shows key and source
+- [x] `config list` default hides sources for defaults, `--verbose` shows all sources
+- [x] **Security**: Impossible to store API keys in repo config (enforced by Pydantic models)
+- [x] Maintain CLI interface contract (all STORY-0001.1.1 tests must pass - source indicators are additive enhancements, not breaking changes)
+- [x] Cross-platform compatibility: Config paths work correctly on Windows/macOS/Linux
+- [x] OpenAI only (no other providers in MVP)
+- [x] All BDD scenarios pass (persistence, precedence, validation, security, TUI compliance) - 19/19 passing[^1]
+
+[^1]: 19 scenarios = 10 core config (persistence/precedence) + 9 TUI compliance (progressive disclosure, symbols, tips)
+- [x] Unit test coverage ≥ 85% (actual: 94.55%)
+- [x] ~~Config caching reduces repeated file I/O~~ - **Eliminated**: CLI process model makes caching unnecessary (<1KB files, <10ms load time per commit d2c8899)
+- [x] Code organization meets quality thresholds (no functions >50 lines, no modules >500 lines, cyclomatic complexity ≤10 except get_source()=11, addressed in TASK-7)
+- [x] Edge cases are tested (Unicode [emoji, Chinese, RTL], corruption [truncated, malformed], auto-create directories)
+- [x] Comprehensive user documentation exists in `docs/configuration.md`
+- [x] Windows-specific tests pass in CI
+
+## Child Tasks
+
+| ID | Title | Status | Hours |
+|----|-------|--------|-------|
+| [TASK-0001.1.2.1](TASK-0001.1.2.1.md) | Write BDD Scenarios for User/Repo Config Separation | ✅ Complete | 1.0 |
+| [TASK-0001.1.2.2](TASK-0001.1.2.2.md) | Implement User and Repo Config with Pydantic Settings | ✅ Complete | 1.0 |
+| [TASK-0001.1.2.3](TASK-0001.1.2.3.md) | Integrate with CLI Commands and Add Config Init | ✅ Complete | 2.5 |
+| [TASK-0001.1.2.4](TASK-0001.1.2.4.md) | Security Hardening - Permission Checks | ✅ Complete | 0.5 |
+| [TASK-0001.1.2.5](TASK-0001.1.2.5.md) | Code Documentation Improvements | ✅ Complete | 0.25 |
+| [TASK-0001.1.2.6](TASK-0001.1.2.6.md) | User-Friendly Validation Errors | ✅ Complete | 0.5 |
+| [TASK-0001.1.2.7](TASK-0001.1.2.7.md) | Fix get_source() Complexity Violation | ✅ Complete | 0.25 |
+| [TASK-0001.1.2.8](TASK-0001.1.2.8.md) | Add Essential Edge Case Tests | ✅ Complete | 0.25 |
+| [TASK-0001.1.2.9](TASK-0001.1.2.9.md) | Create Configuration User Documentation | ✅ Complete | 1.0 |
+| [TASK-0001.1.2.10](TASK-0001.1.2.10.md) | Add Windows CI Integration Tests | ✅ Complete | 0.5 |
+
+**Total**: 7.25 hours (was 2.0, +2.5 TUI, +1.25 PR review, +1.5 essential polish)
+**Removed**: 3.25 hours of overengineering eliminated
+
+**Scope Changes**:
+- TASK-7 (config caching, 1.0h) eliminated - CLI architecture makes caching unnecessary (commit d2c8899)
+- TASK-8 reduction (1.5h → 0.25h) - Clean code needs focused complexity fix, not full refactor
+- Net reduction: 2.25 hours of polish work deemed unnecessary after implementation review
+
+## Story Evolution
+
+**Initial Scope** (2025-10-04): Tasks 1-3 for core configuration implementation (2.0 hours)
+
+**Scope Additions**:
+- **2025-10-05 (TUI Compliance)**: Added TUI requirements to TASK-3, increased to 2.5 hours
+- **2025-10-05 (PR #4 Review)**: Added TASK-4, TASK-5, TASK-6 for security, docs, UX (1.25 hours)
+- **2025-10-05 (Performance & Polish)**: Added TASK-7 through TASK-11 for caching, refactoring, edge cases, documentation, Windows CI (4.5 hours)
+
+**Scope Reductions**:
+- **2025-10-05 (Overengineering Removal)**: Removed original TASK-7 (config caching, 1.0h) - CLI process model makes caching pointless. Redesigned original TASK-8 as focused complexity fix (1.5h → 0.25h) - config module is clean, needs targeted fix not refactor. Tasks renumbered 8→7, 9→8, 10→9, 11→10. Net reduction: 3.25 hours.
+
+**Rationale**: PR review feedback identified gaps in security hardening, code documentation, user-friendly errors, edge case coverage, user documentation, and cross-platform testing. Subsequent focused review identified overengineering in proposed caching and refactoring tasks. Final scope balances production quality with pragmatic implementation.
+
+## BDD Specifications
+
+New scenarios to add to [tests/e2e/features/cli.feature](../../../../tests/e2e/features/cli.feature):
+
+```gherkin
+Scenario: config init creates repo structure (default terse output)
+  When I run "gitctx config init"
+  Then the exit code should be 0
+  And the output should be exactly "Initialized .gitctx/"
+  And the output should NOT contain "Created"
+  And the file ".gitctx/config.yml" should exist
+  And the file ".gitctx/.gitignore" should exist
+  And ".gitctx/.gitignore" should contain "# LanceDB vector database - never commit"
+  And ".gitctx/.gitignore" should contain "db/"
+  And ".gitctx/.gitignore" should contain "# Application logs - never commit"
+  And ".gitctx/.gitignore" should contain "logs/"
+  And ".gitctx/.gitignore" should contain "*.log"
+
+Scenario: API keys stored in user config only
+  When I run "gitctx config set api_keys.openai sk-test123"
+  Then the exit code should be 0
+  And the output should contain "set api_keys.openai"
+  And the user config file should exist at "~/.gitctx/config.yml"
+  And the file "~/.gitctx/config.yml" should contain "api_keys:"
+  And the file "~/.gitctx/config.yml" should contain "openai:"
+  And the file "~/.gitctx/config.yml" should contain "sk-test123"
+  And the file ".gitctx/config.yml" should NOT contain "api_keys"
+  And the file ".gitctx/config.yml" should NOT contain "sk-test123"
+
+Scenario: Repo settings stored in repo config only
+  Given I run "gitctx config init"
+  When I run "gitctx config set search.limit 20"
+  Then the exit code should be 0
+  And the output should contain "set search.limit"
+  And the file ".gitctx/config.yml" should contain "search:"
+  And the file ".gitctx/config.yml" should contain "limit: 20"
+  And the file "~/.gitctx/config.yml" should NOT contain "search"
+  And the file "~/.gitctx/config.yml" should NOT contain "limit"
+
+Scenario: OPENAI_API_KEY env var overrides user config
+  Given user config contains "api_keys:\n  openai: sk-file123"
+  And environment variable "OPENAI_API_KEY" is "sk-env456"
+  When I run "gitctx config get api_keys.openai --verbose"
+  Then the output should contain "sk-...456"
+  And the output should contain "(from OPENAI_API_KEY)"
+
+Scenario: GITCTX env var overrides repo config
+  Given repo config contains "search:\n  limit: 10"
+  And environment variable "GITCTX_SEARCH__LIMIT" is "30"
+  When I run "gitctx config get search.limit --verbose"
+  Then the output should contain "30"
+  And the output should contain "(from GITCTX_SEARCH__LIMIT)"
+
+Scenario: config list shows both user and repo settings
+  Given user config contains "api_keys:\n  openai: sk-test123"
+  And repo config contains "search:\n  limit: 20"
+  When I run "gitctx config list"
+  Then the output should contain "api_keys.openai=sk-...123 (from user config)"
+  And the output should contain "search.limit=20 (from repo config)"
+
+Scenario: Config validation catches invalid values
+  Given I run "gitctx config init"
+  When I run "gitctx config set search.limit invalid"
+  Then the exit code should be 2
+  And the output should contain "validation error"
+
+Scenario: Repo config is safe to commit (no secrets)
+  Given I run "gitctx config init"
+  And I run "gitctx config set search.limit 20"
+  And I run "gitctx config set api_keys.openai sk-secret123"
+  Then the file ".gitctx/config.yml" should contain "search:"
+  And the file ".gitctx/config.yml" should contain "limit: 20"
+  And the file ".gitctx/config.yml" should NOT contain "sk-"
+  And the file ".gitctx/config.yml" should NOT contain "api_keys"
+  And the file "~/.gitctx/config.yml" should contain "api_keys:"
+  And the file "~/.gitctx/config.yml" should contain "sk-secret123"
+
+Scenario: Malformed YAML file shows clear error
+  Given repo config contains invalid YAML "search:\n  limit: [unclosed"
+  When I run "gitctx config get search.limit"
+  Then the exit code should be 1
+  And the output should contain "Failed to parse config file"
+
+Scenario: Permission denied on config save shows clear error
+  Given repo config file exists with read-only permissions
+  When I run "gitctx config set search.limit 30"
+  Then the exit code should be 6
+  And the output should contain "Permission denied"
+```
+
+## Technical Design
+
+### Configuration Schema
+
+**User Config** (`~/.gitctx/config.yml`) - Secrets only, never committed:
+```yaml
+# ~/.gitctx/config.yml
+api_keys:
+  openai: sk-abc123...  # Only OpenAI for MVP
+```
+
+**Repo Config** (`.gitctx/config.yml`) - Team settings, committed to git:
+```yaml
+# .gitctx/config.yml
+# Default content created by 'gitctx config init'
+search:
+  limit: 10
+  rerank: true
+
+index:
+  chunk_size: 1000
+  chunk_overlap: 200
+
+model:
+  embedding: text-embedding-3-large
+```
+
+**Note**: The `config init` command creates `.gitctx/config.yml` with the above default values by calling `RepoConfig().save()`, which serializes the Pydantic model defaults to YAML.
+
+**Repo Config Protection** (`.gitctx/.gitignore`) - Excludes local data:
+```gitignore
+# LanceDB vector database - never commit
+db/
+
+# Application logs - never commit
+logs/
+*.log
+```
+
+### Pydantic Settings Implementation
+
+**Three separate modules for security separation:**
+
+```python
+# src/gitctx/core/user_config.py
+"""User-level configuration (API keys only)."""
+from pathlib import Path
+from typing import Any
+import os
+from pydantic import BaseModel, Field, SecretStr
+from pydantic_settings import (
+    BaseSettings,
+    SettingsConfigDict,
+    PydanticBaseSettingsSource,
+    YamlConfigSettingsSource,
+)
+
+class ApiKeys(BaseModel):
+    """API key configuration."""
+    openai: SecretStr | None = Field(default=None)
+
+class ProviderEnvSource(PydanticBaseSettingsSource):
+    """Custom source for OPENAI_API_KEY env var."""
+
+    def get_field_value(self, field, field_name):
+        # Not used - only __call__ is invoked
+        raise NotImplementedError()
+
+    def __call__(self) -> dict[str, Any]:
+        d = {}
+        if openai_key := os.getenv("OPENAI_API_KEY"):
+            d["api_keys"] = {"openai": openai_key}
+        return d
+
+class UserConfig(BaseSettings):
+    """User config (~/.gitctx/config.yml) - API keys only."""
+    api_keys: ApiKeys = Field(default_factory=ApiKeys)
+
+    model_config = SettingsConfigDict(
+        yaml_file=str(Path.home() / ".gitctx" / "config.yml"),
+        case_sensitive=False,
+        validate_default=True,
+    )
+
+    @classmethod
+    def settings_customise_sources(cls, settings_cls, init_settings, env_settings, dotenv_settings, file_secret_settings):
+        return (
+            init_settings,
+            ProviderEnvSource(settings_cls),  # OPENAI_API_KEY
+            YamlConfigSettingsSource(settings_cls),
+        )
+```
+
+```python
+# src/gitctx/core/repo_config.py
+"""Repo-level configuration (team settings only)."""
+from pathlib import Path
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class SearchSettings(BaseModel):
+    limit: int = Field(default=10, gt=0, le=100)
+    rerank: bool = True
+
+class IndexSettings(BaseModel):
+    chunk_size: int = Field(default=1000, gt=0)
+    chunk_overlap: int = Field(default=200, ge=0)
+
+class ModelSettings(BaseModel):
+    embedding: str = "text-embedding-3-large"
+
+class RepoConfig(BaseSettings):
+    """Repo config (.gitctx/config.yml) - team settings only."""
+    search: SearchSettings = Field(default_factory=SearchSettings)
+    index: IndexSettings = Field(default_factory=IndexSettings)
+    model: ModelSettings = Field(default_factory=ModelSettings)
+
+    model_config = SettingsConfigDict(
+        yaml_file=".gitctx/config.yml",
+        env_prefix="GITCTX_",
+        env_nested_delimiter="__",
+        case_sensitive=False,
+    )
+```
+
+```python
+# src/gitctx/core/config.py
+"""Aggregates user and repo config with smart routing."""
+from pathlib import Path
+from typing import Any
+
+class GitCtxSettings:
+    """Aggregator that routes config by key pattern."""
+
+    def __init__(self):
+        self.user = UserConfig()
+        self.repo = RepoConfig()
+
+    def get(self, key: str) -> Any:
+        """Get config value, routing by key pattern."""
+        if key.startswith("api_keys."):
+            return self._get_from_user(key)
+        else:
+            return self._get_from_repo(key)
+
+    def set(self, key: str, value: Any) -> None:
+        """Set config value, routing by key pattern."""
+        if key.startswith("api_keys."):
+            self._set_in_user(key, value)
+            self.user.save()  # → ~/.gitctx/config.yml
+        else:
+            self._set_in_repo(key, value)
+            self.repo.save()  # → .gitctx/config.yml
+
+def init_repo_config() -> None:
+    """Initialize .gitctx/ structure."""
+    gitctx_dir = Path(".gitctx")
+    gitctx_dir.mkdir(exist_ok=True)
+
+    # Create config.yml
+    config_file = gitctx_dir / "config.yml"
+    if not config_file.exists():
+        RepoConfig().save()
+
+    # Create .gitignore
+    gitignore_content = """# LanceDB vector database - never commit
+db/
+
+# Application logs - never commit
+logs/
+*.log
+"""
+    (gitctx_dir / ".gitignore").write_text(gitignore_content)
+```
+
+### Precedence Examples
+
+**Example 1: User config - OPENAI_API_KEY env var wins**
+```bash
+# ~/.gitctx/config.yml contains: api_keys.openai: sk-file123
+export OPENAI_API_KEY=sk-provider789
+
+gitctx config get api_keys.openai
+# Output: api_keys.openai = sk-...789 (from OPENAI_API_KEY)
+```
+
+**Example 2: User config - YAML fallback**
+```bash
+gitctx config set api_keys.openai sk-file123
+gitctx config get api_keys.openai
+# Output: api_keys.openai = sk-...123 (from user config)
+```
+
+**Example 3: Repo config - GITCTX env var overrides YAML**
+```bash
+# .gitctx/config.yml contains: search.limit: 10
+export GITCTX_SEARCH__LIMIT=30
+
+gitctx config get search.limit
+# Output: search.limit = 30 (from GITCTX_SEARCH__LIMIT)
+```
+
+**Example 4: Repo config - YAML fallback**
+```bash
+gitctx config init
+gitctx config set search.limit 20
+gitctx config get search.limit
+# Output: search.limit = 20 (from repo config)
+```
+
+### CLI Output Format (TUI_GUIDE.md Compliant)
+
+**config init** - Initialize repo structure (NEW):
+```bash
+# Default (terse)
+$ gitctx config init
+Initialized .gitctx/
+
+💡 Tip
+API keys are stored securely in ~/.gitctx/config.yml with file permissions 0600.
+Team settings in .gitctx/config.yml are safe to commit.
+
+# Verbose mode
+$ gitctx config init --verbose
+Initialized .gitctx/
+  Created .gitctx/config.yml
+  Created .gitctx/.gitignore
+
+Next steps:
+  1. Set your API key: gitctx config set api_keys.openai sk-...
+  2. Index your repo: gitctx index
+  3. Commit to share: git add .gitctx/ && git commit -m 'chore: Add gitctx embeddings'
+
+# Quiet mode
+$ gitctx config init --quiet
+(no output)
+```
+
+**config get** - Progressive disclosure (quiet/default/verbose):
+```bash
+# Default (terse) - value only, like git
+$ gitctx config get api_keys.openai
+sk-...789
+
+# Verbose - show key and source
+$ gitctx config get api_keys.openai --verbose
+api_keys.openai = sk-...789 (from OPENAI_API_KEY)
+
+# Quiet - value only (same as default, for scripting)
+$ gitctx config get api_keys.openai --quiet
+sk-...789
+```
+
+**config list** - Progressive disclosure:
+```bash
+# Default - hide sources for defaults (terse)
+$ gitctx config list
+api_keys.openai=sk-...123 (from user config)
+search.limit=20 (from repo config)
+search.rerank=true
+index.chunk_size=1000
+index.chunk_overlap=200
+model.embedding=text-embedding-3-large
+
+# Verbose - show ALL sources including defaults
+$ gitctx config list --verbose
+api_keys.openai=sk-...123 (from user config)
+search.limit=20 (from repo config)
+search.rerank=true (default)
+index.chunk_size=1000 (default)
+index.chunk_overlap=200 (default)
+model.embedding=text-embedding-3-large (default)
+
+# Quiet - just key=value
+$ gitctx config list --quiet
+api_keys.openai=sk-...123
+search.limit=20
+search.rerank=true
+index.chunk_size=1000
+index.chunk_overlap=200
+model.embedding=text-embedding-3-large
+```
+
+**config set** - Routes automatically:
+```bash
+# Default (terse)
+$ gitctx config set api_keys.openai sk-test123
+set api_keys.openai  # → ~/.gitctx/config.yml
+
+$ gitctx config set search.limit 20
+set search.limit  # → .gitctx/config.yml
+
+# Quiet mode
+$ gitctx config set search.limit 20 --quiet
+(no output)
+```
+
+**Platform Symbols** - Auto-fallback on Windows cmd.exe:
+```bash
+# Modern terminals (macOS, Linux, Windows Terminal)
+$ gitctx config init
+✓ Initialized .gitctx/
+
+# Legacy Windows cmd.exe
+C:\> gitctx config init
+[OK] Initialized .gitctx/
+```
+
+## Dependencies
+
+Add to `pyproject.toml`:
+```toml
+dependencies = [
+    "typer>=0.12.0",
+    "rich>=13.7.0",
+    "pyyaml>=6.0.1",  # Already present
+    "shellingham>=1.5.0",
+    "pydantic>=2.11.0",  # NEW
+    "pydantic-settings[yaml]>=2.11.0",  # NEW - [yaml] extra required for YAML support
+]
+```
+
+## Success Metrics
+
+- **Security**: API keys NEVER in repo config (enforced by Pydantic models)
+- **Config Persistence**: Settings survive across sessions
+- **UX Win**: Users with `OPENAI_API_KEY` don't need to configure anything
+- **Team Sharing**: `.gitctx/` safe to commit, shared across team
+- **Type Safety**: Invalid configs caught immediately with helpful errors
+- **Test Coverage**: ≥ 85% coverage maintained
+- **Interface Compatible**: All 78 tests from STORY-0001.1.1 pass
+- **BDD Scenarios**: All persistence, precedence, validation, and security scenarios pass
+
+## Migration from STORY-0001.1.1
+
+Current implementation uses in-memory `_config_store` dict. This story:
+- Replaces in-memory dict with `UserConfig` and `RepoConfig` instances
+- Adds two-file persistence (user vs repo separation)
+- Adds type validation
+- Adds environment variable precedence (different per config type)
+- Adds `config init` command for repo setup
+- **Maintains CLI interface contract** (all existing tests pass)
+- **Adds security**: API keys physically cannot be stored in repo
+
+## Estimation Validation
+
+- **Story Points**: 2 SP = 2 hours (per Fibonacci scale)
+- **Task Hours**: 0.5 + 1.0 + 0.5 = 2.0 hours ✅
+- **Estimates align with story points**
+
+**Complexity Note**: TASK-0001.1.2.2 implements 3 separate modules (~380 lines total) with custom Pydantic sources, routing logic, and comprehensive error handling. If implementation exceeds 2 hours due to debugging/edge cases, consider adjusting to 3 SP retrospectively. The conservative 2 SP estimate assumes efficient implementation following the detailed technical design.
+
+## Performance Targets
+
+- Config load time: <10ms
+- Config save time: <50ms
+- YAML file size: <1KB for typical configs
+- Memory footprint: <100KB for config in memory
+
+## Test Fixtures Reference
+
+**CRITICAL**: This story uses existing comprehensive fixtures. **NO NEW FIXTURES NEEDED.**
+
+### Available Fixtures (tests/conftest.py)
+
+**For Unit Tests** - Use these in `tests/unit/core/test_*_config.py`:
+
+1. **`temp_home`** (Path) - Isolated HOME directory
+   - **Already creates `.gitctx/` subdirectory**
+   - Use with `monkeypatch.setattr("pathlib.Path.home", lambda: temp_home)`
+   - Prevents writing to developer's real home directory
+
+2. **`git_isolation_base`** (dict[str, str]) - Security isolation environment vars
+   - Use with `monkeypatch.setenv()` to apply isolation
+   - Prevents access to SSH keys, GPG keys, git config
+
+3. **`cli_runner`** (CliRunner) - In-process CLI testing
+   - For unit tests of CLI commands
+   - Faster than subprocess, good for quick CLI validation
+
+### Available Fixtures (tests/e2e/conftest.py)
+
+**For E2E/BDD Tests** - Use these in step definitions:
+
+1. **`e2e_git_isolation_env`** (dict[str, str]) - Complete subprocess environment
+   - **Contains isolated HOME** via `e2e_git_isolation_env["HOME"]`
+   - Isolated HOME **already has `.gitctx/` directory created**
+   - Use `Path(e2e_git_isolation_env["HOME"])` to access
+
+2. **`e2e_env_factory`** (callable) - Custom environment factory
+   - Create environments with custom vars: `e2e_env_factory(OPENAI_API_KEY="sk-test")`
+   - Security-checked: prevents overriding isolation vars
+   - Returns complete isolated environment dict
+
+3. **`e2e_cli_runner`** (CliRunner) - Subprocess-isolated CLI runner
+   - For E2E tests requiring true isolation
+   - Automatically uses `e2e_git_isolation_env`
+
+4. **`e2e_git_repo`** (Path) - Real git repository with commits
+   - Use for scenarios requiring git operations
+   - Fully isolated from developer's git config
+
+### Available Fixtures (tests/e2e/steps/cli_steps.py)
+
+**For BDD Step Definitions** - Already exist, just use them:
+
+1. **`context`** (dict[str, Any]) - **Already exists!**
+   - Stores `result`, `output`, `exit_code` between steps
+   - Used by existing `@when('I run "{command}")` step
+   - Add custom keys as needed (e.g., `context["custom_env"]`)
+
+### Existing Step Definitions
+
+**Already implemented** in [tests/e2e/steps/cli_steps.py](../../../../tests/e2e/steps/cli_steps.py):
+
+- `@when('I run "{command}")` - Executes command via subprocess with isolation
+- `@then('the output should contain "{text}")` - Checks stdout
+- `@then('the output should not contain "{text}")` - Negative check
+- `@then("the exit code should be 0")` - Success check
+- `@then("the exit code should be {code:d}")` - Specific code check
+- `@then("the exit code should not be 0")` - Failure check
+
+**New step definitions needed** (add to cli_steps.py):
+
+- `@given('user config contains "{content}"')` - Setup user config file
+- `@given('repo config contains "{content}"')` - Setup repo config file
+- `@given('environment variable "{var}" is "{value}"')` - Set env var for next command
+- `@then('the file "{path}" should exist')` - Check file existence
+- `@then('the file "{path}" should contain "{content}"')` - Check file content
+- `@then('the file "{path}" should NOT contain "{content}"')` - Negative file check
+
+### Fixture Usage Patterns
+
+**Unit Test Pattern** (using temp_home):
+```python
+def test_user_config_saves(temp_home, monkeypatch):
+    """temp_home already has .gitctx/ created."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: temp_home)
+
+    config_file = temp_home / ".gitctx" / "config.yml"
+    # config_file.parent already exists!
+```
+
+**E2E Step Pattern** (using e2e_git_isolation_env):
+```python
+@given('user config contains "{content}"')
+def setup_user_config(e2e_git_isolation_env: dict[str, str], content: str):
+    home = Path(e2e_git_isolation_env["HOME"])
+    config = home / ".gitctx" / "config.yml"
+    # home / ".gitctx" already exists!
+    config.write_text(content.replace('\\n', '\n'))
+```
+
+**E2E Env Var Pattern** (using e2e_env_factory + context):
+```python
+@given('environment variable "{var}" is "{value}"')
+def setup_env(e2e_env_factory, context: dict[str, Any], var: str, value: str):
+    """Store env var for next run_command to use."""
+    if "custom_env" not in context:
+        context["custom_env"] = {}
+    context["custom_env"][var] = value
+
+# Then in run_command step (already exists, no modification needed):
+# It can check context["custom_env"] and use e2e_env_factory
+```
+
+## Notes
+
+- **Security-First**: User/repo config separation prevents accidental secret commits
+- **BDD/TDD Workflow**: Write tests first (RED), implement (GREEN), refactor
+- **OpenAI Only**: No Anthropic, Cohere, or other providers (YAGNI principle)
+- **Pydantic Choice**: Industry-standard (FastAPI), type-safe, future-proof
+- **Smart Routing**: CLI automatically routes by key pattern (transparent to user)
+- **No Scope Creep**: Simple YAML + env vars now, cloud secrets available later
+- **User Experience**: Respects existing `OPENAI_API_KEY` (don't break their workflow)
+- **Comprehensive Fixtures**: 8 existing fixtures provide everything needed - no new fixtures required
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Accidentally committing API keys | **CRITICAL** | Enforced separation via Pydantic models - API keys physically cannot go in repo config |
+| Pydantic Settings learning curve | Low | Excellent docs, standard patterns |
+| YAML file corruption | Medium | Validate on load, backup on save |
+| Breaking CLI interface contract | High | Extensive BDD tests, all 78 existing tests must pass |
+| Complex routing logic | Medium | Clear key-based routing, comprehensive tests |
+
+## Related Epics
+
+- **Enables EPIC-0001.2** (Real Indexing): Indexing needs persistent OpenAI API key
+- **Completes EPIC-0001.1** (CLI Foundation): 10/10 story points (100%)
+
+---
+
+**Created**: 2025-10-04
+**Last Updated**: 2025-10-05
+**Completed**: 2025-10-05

--- a/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.1.md
+++ b/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.1.md
@@ -1,0 +1,716 @@
+# TASK-0001.1.2.1: Write BDD Scenarios for User/Repo Config Separation
+
+**Parent Story**: [STORY-0001.1.2](README.md)
+**Status**: ✅ Complete
+**Estimated Hours**: 1.0 (was 0.5, +0.5 for TUI compliance scenarios)
+**Actual Hours**: 1.0
+
+## Description
+
+**RED Phase** - Write failing tests first for persistent configuration with user/repo separation and security enforcement.
+
+This task implements the BDD/TDD workflow's first step: write comprehensive BDD scenarios and unit tests that define the expected behavior of security-first configuration management with user and repo config separation. All tests will fail initially (RED) because the implementation doesn't exist yet.
+
+## Implementation Checklist
+
+### BDD Scenarios (E2E)
+
+- [x] Add scenarios to `tests/e2e/features/cli.feature`:
+  - [x] config init creates repo structure (default terse mode)
+  - [x] API keys stored in user config only (validates file persistence)
+  - [x] Repo settings stored in repo config only (validates file persistence)
+  - [x] OPENAI_API_KEY env var overrides user config
+  - [x] GITCTX env var overrides repo config
+  - [x] config list shows both user and repo settings
+  - [x] Config validation catches invalid values (exit code 2)
+  - [x] Repo config is safe to commit (validates secrets in user config, settings in repo config)
+  - [x] Malformed YAML shows clear error
+  - [x] Permission denied shows clear error (exit code 6)
+  - [x] **TUI: config init quiet mode suppresses output**
+  - [x] **TUI: config init verbose mode shows details**
+  - [x] **TUI: config get default mode shows value only (terse)**
+  - [x] **TUI: config get verbose mode shows key and source**
+  - [x] **TUI: config get quiet mode outputs value only**
+  - [x] **TUI: config list default mode hides sources for defaults (terse)**
+  - [x] **TUI: config list verbose mode shows all sources**
+  - [x] **TUI: config set default mode shows terse confirmation (validates file persistence)**
+  - [x] **TUI: config set quiet mode suppresses output (validates file persistence)**
+  - [x] **TUI: config set api key persists to user config (validates file content)**
+  - [x] **TUI: First-run tip appears once for config command**
+  - [x] **TUI: Platform symbols fallback on Windows cmd.exe**
+- [x] Add step definitions to `tests/e2e/steps/cli_steps.py`:
+  - [x] `Given user config contains "key: value"`
+  - [x] `Given repo config contains "key: value"`
+  - [x] `Given environment variable "VAR" is "value"`
+  - [x] `Then the file "path" should exist`
+  - [x] `Then the file "path" should contain "content"`
+  - [x] `Then the file "path" should NOT contain "content"`
+- [x] Run BDD tests: `uv run pytest tests/e2e/ -k config` - **all 22 config scenarios PASSING** ✅
+
+### Unit Tests (TDD)
+
+**Test File Structure** (3 modules = 3 test files):
+- `src/gitctx/core/user_config.py` → `tests/unit/core/test_user_config.py`
+- `src/gitctx/core/repo_config.py` → `tests/unit/core/test_repo_config.py`
+- `src/gitctx/core/config.py` → `tests/unit/core/test_config.py`
+
+- [x] Create `tests/unit/core/test_user_config.py`:
+  - [x] `test_user_config_loads_from_yaml()` - UserConfig reads YAML
+  - [x] `test_user_config_saves_to_yaml()` - UserConfig writes YAML with 0600 permissions
+  - [x] `test_openai_api_key_env_var_precedence()` - OPENAI_API_KEY wins
+  - [x] `test_user_config_only_has_api_keys()` - Rejects non-secret fields
+  - [x] `test_secret_str_masks_api_keys()` - SecretStr masking
+  - [x] `test_user_config_windows_path()` - Path.home() works on Windows (skip on non-Windows)
+- [x] Create `tests/unit/core/test_repo_config.py`:
+  - [x] `test_repo_config_loads_from_yaml()` - RepoConfig reads YAML
+  - [x] `test_repo_config_saves_to_yaml()` - RepoConfig writes YAML with 0644 permissions
+  - [x] `test_gitctx_env_var_overrides_yaml()` - GITCTX_* beats YAML
+  - [x] `test_repo_config_only_has_settings()` - Rejects api_keys field
+  - [x] `test_repo_config_validates_types()` - Type validation works
+  - [x] `test_malformed_yaml_error()` - Clear error on malformed YAML
+  - [x] `test_permission_denied_error()` - Clear error on permission denied
+- [x] Create `tests/unit/core/test_config.py`:
+  - [x] `test_gitctx_settings_routes_api_keys_to_user()` - Routing works
+  - [x] `test_gitctx_settings_routes_settings_to_repo()` - Routing works
+  - [x] `test_init_repo_config_creates_structure()` - Creates files
+  - [x] `test_gitignore_content()` - Correct .gitignore content (including comments)
+- [x] **TUI Tests**: Add to `tests/unit/cli/test_config.py`:
+  - [x] `test_symbols_fallback_on_legacy_windows()` - Validates ASCII fallback in config commands
+  - [x] `test_symbols_use_unicode_on_modern_terminals()` - Validates ✓ ✗ symbols in config commands
+  - [x] `test_first_run_creates_marker_file()` - Validates marker file creation for config command
+  - [x] `test_subsequent_runs_skip_tips()` - Validates tip shown only once for config command
+  - [x] `test_show_tip_uses_ascii_box_on_windows()` - Box styling matches platform
+- [x] Run unit tests: `uv run pytest tests/unit/core/ tests/unit/cli/ -v` - **all 36 core + 28 CLI tests PASSING** ✅
+
+### Test Coverage Plan
+
+- [x] Confirm test coverage plan meets 85%+ target with explicit file mappings:
+  - `tests/unit/core/test_user_config.py`:
+    - User config loading (YAML, OPENAI_API_KEY env var, defaults)
+    - User config precedence (OPENAI_API_KEY > YAML)
+    - SecretStr masking (API keys hidden)
+    - User config persistence (~/.gitctx/config.yml with 0600 permissions)
+  - `tests/unit/core/test_repo_config.py`:
+    - Repo config loading (YAML, GITCTX_* env vars, defaults)
+    - Repo config precedence (GITCTX_* > YAML)
+    - Type validation (type errors, invalid values)
+    - Repo config persistence (.gitctx/config.yml with 0644 permissions)
+  - `tests/unit/core/test_config.py`:
+    - GitCtxSettings routing (api_keys.* → user, others → repo)
+    - get_source() method (returns correct source indicators)
+    - init_repo_config() function (creates .gitctx/ with .gitignore)
+    - Security (user/repo separation enforced)
+  - **Target ACHIEVED**: user_config: 100%, repo_config: 100%, config: 90.77% ✅
+
+## BDD Scenarios Detail
+
+Add to `tests/e2e/features/cli.feature`:
+
+```gherkin
+Scenario: config init creates repo structure (default terse output)
+  When I run "gitctx config init"
+  Then the exit code should be 0
+  And the output should be exactly "Initialized .gitctx/"
+  And the output should NOT contain "Created"
+  And the output should NOT contain "Next steps"
+  And the file ".gitctx/config.yml" should exist
+  And the file ".gitctx/.gitignore" should exist
+  And ".gitctx/.gitignore" should contain "# LanceDB vector database - never commit"
+  And ".gitctx/.gitignore" should contain "db/"
+  And ".gitctx/.gitignore" should contain "# Application logs - never commit"
+  And ".gitctx/.gitignore" should contain "logs/"
+  And ".gitctx/.gitignore" should contain "*.log"
+
+Scenario: config init quiet mode suppresses all output
+  When I run "gitctx config init --quiet"
+  Then the exit code should be 0
+  And the output should be empty
+
+Scenario: config init verbose mode shows detailed output
+  When I run "gitctx config init --verbose"
+  Then the exit code should be 0
+  And the output should contain "Initialized .gitctx/"
+  And the output should contain "Created .gitctx/config.yml"
+  And the output should contain "Created .gitctx/.gitignore"
+  And the output should contain "Next steps:"
+  And the output should contain "1. Set your API key: gitctx config set api_keys.openai sk-..."
+  And the output should contain "2. Index your repo: gitctx index"
+  And the output should contain "3. Commit to share: git add .gitctx/"
+
+Scenario: API keys stored in user config only
+  When I run "gitctx config set api_keys.openai sk-test123"
+  Then the exit code should be 0
+  And the output should contain "set api_keys.openai"
+  And the user config file should exist at "~/.gitctx/config.yml"
+  And the file "~/.gitctx/config.yml" should contain "api_keys:"
+  And the file "~/.gitctx/config.yml" should contain "openai:"
+  And the file "~/.gitctx/config.yml" should contain "sk-test123"
+  And the file ".gitctx/config.yml" should NOT contain "api_keys"
+  And the file ".gitctx/config.yml" should NOT contain "sk-test123"
+
+Scenario: Repo settings stored in repo config only
+  Given I run "gitctx config init"
+  When I run "gitctx config set search.limit 20"
+  Then the exit code should be 0
+  And the output should contain "set search.limit"
+  And the file ".gitctx/config.yml" should contain "search:"
+  And the file ".gitctx/config.yml" should contain "limit: 20"
+  And the file "~/.gitctx/config.yml" should NOT contain "search"
+  And the file "~/.gitctx/config.yml" should NOT contain "limit"
+
+Scenario: config get default mode shows value only (terse)
+  Given user config contains "api_keys:\n  openai: sk-test123"
+  When I run "gitctx config get api_keys.openai"
+  Then the exit code should be 0
+  And the output should be exactly "sk-...123"
+  And the output should NOT contain "api_keys.openai"
+  And the output should NOT contain "(from"
+
+Scenario: config get verbose mode shows key and source
+  Given user config contains "api_keys:\n  openai: sk-test123"
+  When I run "gitctx config get api_keys.openai --verbose"
+  Then the exit code should be 0
+  And the output should contain "api_keys.openai = sk-...123 (from user config)"
+
+Scenario: config get quiet mode outputs value only with no formatting
+  Given user config contains "api_keys:\n  openai: sk-test123"
+  When I run "gitctx config get api_keys.openai --quiet"
+  Then the exit code should be 0
+  And the output should be exactly "sk-...123"
+
+Scenario: OPENAI_API_KEY env var overrides user config
+  Given user config contains "api_keys:\n  openai: sk-file123"
+  And environment variable "OPENAI_API_KEY" is "sk-env456"
+  When I run "gitctx config get api_keys.openai --verbose"
+  Then the output should contain "sk-...456"
+  And the output should contain "(from OPENAI_API_KEY)"
+
+Scenario: GITCTX env var overrides repo config
+  Given repo config contains "search:\n  limit: 10"
+  And environment variable "GITCTX_SEARCH__LIMIT" is "30"
+  When I run "gitctx config get search.limit"
+  Then the output should contain "30"
+  And the output should contain "(from GITCTX_SEARCH__LIMIT)"
+
+Scenario: config list default mode hides sources for defaults (terse)
+  Given user config contains "api_keys:\n  openai: sk-test123"
+  And repo config contains "search:\n  limit: 20"
+  When I run "gitctx config list"
+  Then the output should contain "api_keys.openai=sk-...123 (from user config)"
+  And the output should contain "search.limit=20 (from repo config)"
+  And the output should contain "model.embedding=text-embedding-3-large"
+  And the output should NOT contain "(default)"
+
+Scenario: config list verbose mode shows all sources
+  Given user config contains "api_keys:\n  openai: sk-test123"
+  When I run "gitctx config list --verbose"
+  Then the output should contain "api_keys.openai=sk-...123 (from user config)"
+  And the output should contain "model.embedding=text-embedding-3-large (default)"
+  And the output should contain "search.limit=10 (default)"
+
+Scenario: config set default mode shows terse confirmation
+  Given I run "gitctx config init"
+  When I run "gitctx config set search.limit 20"
+  Then the exit code should be 0
+  And the output should be exactly "set search.limit"
+  And the file ".gitctx/config.yml" should contain "search:"
+  And the file ".gitctx/config.yml" should contain "limit: 20"
+  And the file "~/.gitctx/config.yml" should NOT contain "search"
+
+Scenario: config set quiet mode suppresses output
+  Given I run "gitctx config init"
+  When I run "gitctx config set search.limit 20 --quiet"
+  Then the exit code should be 0
+  And the output should be empty
+  And the file ".gitctx/config.yml" should contain "search:"
+  And the file ".gitctx/config.yml" should contain "limit: 20"
+
+Scenario: config set api key persists to user config
+  When I run "gitctx config set api_keys.openai sk-test456"
+  Then the exit code should be 0
+  And the file "~/.gitctx/config.yml" should exist
+  And the file "~/.gitctx/config.yml" should contain "api_keys:"
+  And the file "~/.gitctx/config.yml" should contain "openai:"
+  And the file "~/.gitctx/config.yml" should contain "sk-test456"
+  And the file ".gitctx/config.yml" should NOT contain "sk-test456"
+  And the file ".gitctx/config.yml" should NOT contain "api_keys"
+
+Scenario: Config validation catches invalid values
+  Given I run "gitctx config init"
+  When I run "gitctx config set search.limit invalid"
+  Then the exit code should be 2
+  And the output should contain "validation error"
+
+Scenario: Repo config is safe to commit (no secrets)
+  Given I run "gitctx config init"
+  And I run "gitctx config set search.limit 20"
+  And I run "gitctx config set api_keys.openai sk-secret123"
+  Then the file ".gitctx/config.yml" should contain "search:"
+  And the file ".gitctx/config.yml" should contain "limit: 20"
+  And the file ".gitctx/config.yml" should NOT contain "sk-"
+  And the file ".gitctx/config.yml" should NOT contain "api_keys"
+  And the file "~/.gitctx/config.yml" should contain "api_keys:"
+  And the file "~/.gitctx/config.yml" should contain "sk-secret123"
+
+Scenario: Malformed YAML file shows clear error
+  Given repo config contains invalid YAML "search:\n  limit: [unclosed"
+  When I run "gitctx config get search.limit"
+  Then the exit code should be 1
+  And the output should contain "Failed to parse config file"
+
+Scenario: Permission denied on config save shows clear error
+  Given repo config file exists with read-only permissions
+  When I run "gitctx config set search.limit 30"
+  Then the exit code should be 6
+  And the output should contain "Permission denied"
+
+Scenario: First-run tip appears once for config command
+  When I run "gitctx config init"
+  Then the output should contain "Tip"
+  And the output should contain "API keys are stored securely"
+  When I run "gitctx config init" in a new directory
+  Then the output should NOT contain "Tip"
+
+Scenario: Platform symbols use fallback on Windows cmd.exe
+  When I run "gitctx config init" on Windows legacy terminal
+  Then the output should contain "[OK]"
+  And the output should NOT contain "✓"
+```
+
+## Step Definitions Implementation
+
+Add to `tests/e2e/steps/cli_steps.py`:
+
+**CRITICAL REUSE REQUIREMENTS**:
+
+1. **context fixture ALREADY EXISTS** - DO NOT CREATE A NEW ONE!
+   - Location: `tests/e2e/steps/cli_steps.py:13-15`
+   - Just import and use it in your new step definitions
+   - Creating a duplicate will cause pytest fixture conflicts
+
+2. **`.gitctx/` directory ALREADY EXISTS** in fixtures:
+   - `temp_home` already creates `.gitctx/` (conftest.py:79)
+   - `e2e_git_isolation_env["HOME"]` already has `.gitctx/`
+   - **DO NOT** call `mkdir()` for `.gitctx/` - it's redundant!
+
+3. **6 step definitions ALREADY EXIST** - REUSE THEM:
+   - `@when('I run "{command}"')` - EXISTS, don't recreate
+   - `@then('the output should contain "{text}"')` - EXISTS
+   - `@then('the output should not contain "{text}"')` - EXISTS
+   - `@then("the exit code should be 0")` - EXISTS
+   - `@then("the exit code should be {code:d}")` - EXISTS
+   - `@then("the exit code should not be 0")` - EXISTS
+
+4. **run_command step** - ENHANCE, don't replace:
+   - Existing implementation in cli_steps.py:26-58
+   - Add support for `context["custom_env"]` and `e2e_env_factory`
+   - Don't rewrite the subprocess logic
+
+```python
+from pathlib import Path
+from typing import Any
+import yaml
+from pytest_bdd import given, then, parsers
+
+@given(parsers.parse('user config contains "{content}"'))
+def setup_user_config(e2e_git_isolation_env: dict[str, str], content: str) -> None:
+    """Create user config file with specified YAML content in isolated HOME.
+
+    CRITICAL: e2e_git_isolation_env["HOME"] already has .gitctx/ directory!
+    DO NOT call mkdir() - it's redundant and already exists.
+    """
+    home = Path(e2e_git_isolation_env["HOME"])
+    config_path = home / ".gitctx" / "config.yml"
+    # .gitctx/ already exists - just write the file
+    config_path.write_text(content.replace('\\n', '\n'))
+
+@given(parsers.parse('repo config contains "{content}"'))
+def setup_repo_config(content: str) -> None:
+    """Create repo config file with specified YAML content in current directory.
+
+    Creates .gitctx/config.yml in the current working directory (test repo).
+    """
+    config_path = Path(".gitctx")
+    config_path.mkdir(exist_ok=True)
+    (config_path / "config.yml").write_text(content.replace('\\n', '\n'))
+
+@given(parsers.parse('environment variable "{var}" is "{value}"'))
+def setup_env_var(context: dict[str, Any], var: str, value: str) -> None:
+    """Set environment variable for next command execution.
+
+    CRITICAL: Stores in context["custom_env"] for run_command to use.
+    This is necessary because monkeypatch doesn't work in subprocess contexts.
+
+    The run_command step will check for context["custom_env"] and use
+    e2e_env_factory to create an environment with these vars.
+    """
+    if "custom_env" not in context:
+        context["custom_env"] = {}
+    context["custom_env"][var] = value
+
+@given(parsers.parse('repo config file exists with read-only permissions'))
+def setup_readonly_repo_config() -> None:
+    """Create read-only repo config file for testing permission errors."""
+    config_path = Path(".gitctx")
+    config_path.mkdir(exist_ok=True)
+    config_file = config_path / "config.yml"
+    config_file.write_text("search:\n  limit: 10\n")
+    config_file.chmod(0o444)  # Read-only
+
+@given(parsers.parse('repo config contains invalid YAML "{content}"'))
+def setup_invalid_yaml_repo_config(content: str) -> None:
+    """Create repo config with invalid YAML for error testing."""
+    config_path = Path(".gitctx")
+    config_path.mkdir(exist_ok=True)
+    (config_path / "config.yml").write_text(content.replace('\\n', '\n'))
+
+@then(parsers.parse('the file "{path}" should exist'))
+def check_file_exists(e2e_git_isolation_env: dict[str, str], path: str) -> None:
+    """Verify file exists at specified path.
+
+    Handles both absolute paths and ~ expansion (to isolated HOME).
+    """
+    if path.startswith("~"):
+        home = Path(e2e_git_isolation_env["HOME"])
+        expanded = home / path[2:]  # Skip "~/"
+    else:
+        expanded = Path(path)
+
+    assert expanded.exists(), f"File not found at {expanded}"
+
+@then(parsers.parse('the file "{path}" should contain "{content}"'))
+def check_file_contains(e2e_git_isolation_env: dict[str, str], path: str, content: str) -> None:
+    """Verify file contains specified content."""
+    if path.startswith("~"):
+        home = Path(e2e_git_isolation_env["HOME"])
+        expanded = home / path[2:]
+    else:
+        expanded = Path(path)
+
+    assert expanded.exists(), f"File not found at {expanded}"
+    file_content = expanded.read_text()
+    assert content in file_content, f"Expected '{content}' in {path}, got: {file_content}"
+
+@then(parsers.parse('the file "{path}" should NOT contain "{content}"'))
+def check_file_not_contains(e2e_git_isolation_env: dict[str, str], path: str, content: str) -> None:
+    """Verify file does NOT contain specified content."""
+    if path.startswith("~"):
+        home = Path(e2e_git_isolation_env["HOME"])
+        expanded = home / path[2:]
+    else:
+        expanded = Path(path)
+
+    if not expanded.exists():
+        return  # File doesn't exist, so it doesn't contain the content
+
+    file_content = expanded.read_text()
+    assert content not in file_content, f"Did not expect '{content}' in {path}, got: {file_content}"
+
+@then(parsers.parse('the user config file should exist at "{path}"'))
+def check_user_config_exists(e2e_git_isolation_env: dict[str, str], path: str) -> None:
+    """Verify user config file exists (alias for better readability in scenarios)."""
+    check_file_exists(e2e_git_isolation_env, path)
+
+@then(parsers.parse('"{filename}" should contain "{content}"'))
+def check_gitignore_content(filename: str, content: str) -> None:
+    """Verify .gitctx/.gitignore contains expected content."""
+    file_path = Path(".gitctx") / filename.replace(".gitctx/", "")
+    assert file_path.exists(), f"File not found: {file_path}"
+    file_content = file_path.read_text()
+    assert content in file_content, f"Expected '{content}' in {file_path}"
+```
+
+## Unit Tests Detail
+
+Create `tests/unit/core/test_config.py`:
+
+**CRITICAL**: Use `temp_home` fixture which **already creates `.gitctx/` directory**!
+
+```python
+"""Unit tests for Pydantic Settings configuration."""
+
+import os
+from pathlib import Path
+import pytest
+from pydantic import ValidationError
+
+# Will fail - module doesn't exist yet
+from gitctx.core.config import GitCtxSettings, ApiKeys, SearchSettings
+
+
+class TestConfigLoading:
+    """Test configuration loading from various sources."""
+
+    def test_config_loads_from_yaml(self, temp_home, monkeypatch):
+        """Config should load settings from YAML file.
+
+        NOTE: temp_home already has .gitctx/ subdirectory created!
+        """
+        # Setup - override Path.home() to return temp_home
+        monkeypatch.setattr("pathlib.Path.home", lambda: temp_home)
+
+        # Write config (temp_home / ".gitctx" already exists!)
+        config_file = temp_home / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: sk-file123\n")
+
+        # Act
+        settings = GitCtxSettings()
+
+        # Assert - will FAIL (no implementation)
+        assert settings.api_keys.openai.get_secret_value() == "sk-file123"
+
+    def test_provider_env_var_highest_precedence(self, temp_home, monkeypatch):
+        """OPENAI_API_KEY should override all other sources."""
+        # Setup - override Path.home() and set env vars
+        monkeypatch.setattr("pathlib.Path.home", lambda: temp_home)
+        monkeypatch.setenv("GITCTX_API_KEYS__OPENAI", "sk-gitctx456")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-provider789")
+
+        # Write config (temp_home / ".gitctx" already exists!)
+        config_file = temp_home / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: sk-file123\n")
+
+        # Act
+        settings = GitCtxSettings()
+
+        # Assert - will FAIL (OPENAI_API_KEY wins)
+        assert settings.api_keys.openai.get_secret_value() == "sk-provider789"
+
+    def test_gitctx_env_var_overrides_yaml(self, temp_home, monkeypatch):
+        """GITCTX_API_KEYS__OPENAI should override YAML."""
+        # Setup
+        monkeypatch.setattr("pathlib.Path.home", lambda: temp_home)
+        monkeypatch.setenv("GITCTX_API_KEYS__OPENAI", "sk-gitctx456")
+
+        # Write config (temp_home / ".gitctx" already exists!)
+        config_file = temp_home / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: sk-file123\n")
+
+        # Act
+        settings = GitCtxSettings()
+
+        # Assert - will FAIL (env var wins)
+        assert settings.api_keys.openai.get_secret_value() == "sk-gitctx456"
+
+    def test_yaml_used_when_no_env_vars(self, temp_home, monkeypatch):
+        """YAML should be used when no env vars are set."""
+        # Setup
+        monkeypatch.setattr("pathlib.Path.home", lambda: temp_home)
+
+        # Write config (temp_home / ".gitctx" already exists!)
+        config_file = temp_home / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: sk-file123\n")
+
+        # Act
+        settings = GitCtxSettings()
+
+        # Assert - will FAIL
+        assert settings.api_keys.openai.get_secret_value() == "sk-file123"
+
+
+class TestConfigValidation:
+    """Test Pydantic validation of configuration values."""
+
+    def test_config_validates_types(self):
+        """Config should validate type correctness."""
+        # Act
+        settings = GitCtxSettings(search={"limit": 20})
+
+        # Assert - will FAIL
+        assert settings.search.limit == 20
+        assert isinstance(settings.search.limit, int)
+
+    def test_config_rejects_invalid_types(self):
+        """Config should reject invalid type values."""
+        # Assert - will FAIL
+        with pytest.raises(ValidationError) as exc_info:
+            GitCtxSettings(search={"limit": "invalid"})
+
+        assert "validation error" in str(exc_info.value).lower()
+
+    def test_secret_str_masks_api_keys(self):
+        """SecretStr should mask API keys in string representation."""
+        # Act
+        api_keys = ApiKeys(openai="sk-test123456")
+
+        # Assert - will FAIL
+        assert "sk-test123456" not in str(api_keys)
+        assert api_keys.openai.get_secret_value() == "sk-test123456"
+
+
+class TestConfigPersistence:
+    """Test saving and loading configuration."""
+
+    def test_config_saves_to_yaml(self, temp_home, monkeypatch):
+        """Config.save() should persist to YAML file.
+
+        NOTE: temp_home already has .gitctx/ directory!
+        """
+        # Setup
+        monkeypatch.setattr("pathlib.Path.home", lambda: temp_home)
+        settings = GitCtxSettings()
+        settings.api_keys.openai = "sk-test123"
+
+        # Act
+        settings.save()
+
+        # Assert - will FAIL
+        config_file = temp_home / ".gitctx" / "config.yml"
+        assert config_file.exists()
+        content = config_file.read_text()
+        assert "openai" in content
+
+    def test_config_directory_already_exists(self, temp_home, monkeypatch):
+        """Config should work when ~/.gitctx/ already exists.
+
+        NOTE: temp_home fixture already creates this directory!
+        """
+        # Setup
+        monkeypatch.setattr("pathlib.Path.home", lambda: temp_home)
+
+        # Verify directory exists (created by temp_home fixture)
+        assert (temp_home / ".gitctx").exists()
+        assert (temp_home / ".gitctx").is_dir()
+
+        # Act - save should work even with existing directory
+        settings = GitCtxSettings()
+        settings.save()
+
+        # Assert - will FAIL
+        assert (temp_home / ".gitctx" / "config.yml").exists()
+
+    def test_config_handles_missing_file(self, temp_home, monkeypatch):
+        """Config should use defaults when YAML file doesn't exist.
+
+        NOTE: temp_home has .gitctx/ directory but no config.yml file.
+        """
+        # Setup
+        monkeypatch.setattr("pathlib.Path.home", lambda: temp_home)
+
+        # Act
+        settings = GitCtxSettings()
+
+        # Assert - will FAIL (should use defaults)
+        assert settings.search.limit == 10  # default
+        assert settings.model.embedding == "text-embedding-3-large"  # default
+```
+
+## Acceptance Criteria
+
+- [x] All BDD scenarios written and added to `cli.feature` (19 new scenarios)
+- [x] All step definitions implemented (11 new step definitions)
+- [x] All unit tests written (33 tests covering all scenarios)
+- [x] Run `uv run pytest` - **all tests FAIL/SKIP** (RED phase) - 19 failed, 33 skipped ✅
+- [x] Test coverage plan documented and meets 85%+ target
+- [x] Tests clearly document expected behavior
+
+## TDD Requirements
+
+**This is the RED phase** - tests must:
+1. Be written before implementation
+2. Fail when run (proving they test real behavior)
+3. Document expected behavior clearly
+4. Cover all acceptance criteria from parent story
+
+## Testing Commands
+
+```bash
+# Run BDD tests (should FAIL)
+uv run pytest tests/e2e/ -k config -v
+
+# Run unit tests (should FAIL)
+uv run pytest tests/unit/core/test_config.py -v
+
+# Run all tests (should show FAILures)
+uv run pytest -v
+
+# Check coverage plan
+uv run pytest --cov=src/gitctx/core/config --cov-report=term-missing
+```
+
+## Implementation Notes
+
+### Enhancing run_command Step
+
+The existing `run_command` step in `tests/e2e/steps/cli_steps.py` needs a small enhancement to support custom env vars from `context["custom_env"]`:
+
+```python
+@when(parsers.parse('I run "{command}"'))
+def run_command(
+    command: str,
+    e2e_git_isolation_env: dict[str, str],
+    e2e_env_factory,
+    context: dict[str, Any]
+) -> None:
+    """
+    Execute a CLI command as subprocess with full isolation.
+
+    CRITICAL: Uses subprocess.run() with isolated environment to ensure
+    true isolation from developer SSH keys, GPG keys, and git config.
+
+    Enhancement: Checks context["custom_env"] for custom environment variables
+    set by previous @given steps (e.g., OPENAI_API_KEY, GITCTX_*).
+    """
+    # Check if custom env vars were set by previous @given steps
+    if "custom_env" in context:
+        env = e2e_env_factory(**context["custom_env"])
+        # Clear for next scenario
+        context.pop("custom_env")
+    else:
+        env = e2e_git_isolation_env
+
+    # Parse the command and convert gitctx to python -m gitctx
+    # (rest of implementation unchanged)
+    if command.startswith("gitctx"):
+        args = command.replace("gitctx", "").strip().split() if command.strip() != "gitctx" else []
+        cmd_parts = [sys.executable, "-m", "gitctx"] + args
+    else:
+        cmd_parts = command.strip().split()
+
+    # Run gitctx as subprocess with full isolation
+    result = subprocess.run(
+        cmd_parts,
+        env=env,  # Now uses custom env if provided
+        capture_output=True,
+        text=True,
+    )
+
+    context["result"] = result
+    context["output"] = result.stdout
+    context["exit_code"] = result.returncode
+```
+
+### Fixture Usage Summary
+
+**Use existing fixtures** - NO new fixtures needed:
+
+- `e2e_git_isolation_env` - Provides isolated HOME with `.gitctx/` already created
+- `e2e_env_factory` - Creates custom environments with additional env vars
+- `context` - **Already exists!** Stores data between steps
+
+**Key Pattern**:
+1. `@given` steps write to `context["custom_env"]`
+2. `@when` step (`run_command`) reads from `context["custom_env"]` and uses `e2e_env_factory`
+3. `@then` steps read from `context["output"]`, `context["exit_code"]`
+
+## Notes
+
+- **RED phase**: Tests should fail because `src/gitctx/core/config.py` doesn't exist
+- **Next task**: TASK-0001.1.2.2 will make these tests pass (GREEN)
+- Import errors are expected - they prove we're testing first
+- **Fixture pattern**: Use `e2e_git_isolation_env` for HOME (already has `.gitctx/`!)
+- **Env vars in E2E**: Store in `context["custom_env"]` for `e2e_env_factory`
+- **Test isolation**: All fixtures follow patterns in `tests/conftest.py` and `tests/e2e/conftest.py`
+- **`context` fixture exists**: Defined in `tests/e2e/steps/cli_steps.py`, just use it!
+
+## Dependencies
+
+- Parent story created
+- `tests/e2e/features/cli.feature` exists
+- `tests/e2e/step_defs/test_cli.py` exists
+- pytest-bdd framework working (from STORY-0001.1.0)
+
+---
+
+**Created**: 2025-10-04
+**Last Updated**: 2025-10-04

--- a/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.10.md
+++ b/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.10.md
@@ -1,0 +1,131 @@
+# TASK-0001.1.2.10: Add Windows CI Integration Tests
+
+**Parent Story**: [STORY-0001.1.2](README.md)
+**Status**: ✅ Complete
+**Estimated Hours**: 0.5
+**Actual Hours**: 0.5
+**Completion Commits**: 46a17b5, 570cd0c
+
+## Objective
+
+Add Windows-specific integration tests to verify config behavior on Windows, particularly around file permissions, path handling, and platform symbols.
+
+## Context
+
+Current tests skip Windows for permission checks. Need proper Windows integration tests to ensure cross-platform compatibility, especially for file permissions (ACLs) and path handling.
+
+## Implementation Checklist
+
+- [x] Add Windows-specific file permission tests (ACL-based)
+- [x] Verify platform symbol selection on Windows cmd.exe vs PowerShell
+- [x] Test Windows path handling (`%USERPROFILE%` expansion)
+- [x] Test CRLF line ending handling in YAML files
+- [x] Verify Unicode support on Windows
+- [x] Remove `pytest.skip` for Windows permission tests where appropriate
+- [x] Run quality gates: `uv run poe fix && uv run poe quality`
+
+## Acceptance Criteria
+
+- Windows file permission tests verify ACL behavior
+- Platform symbols correctly selected on Windows
+- Windows paths (`%USERPROFILE%`) handled correctly
+- CRLF line endings don't break YAML parsing
+- Unicode works on Windows
+- Tests pass in GitHub Actions Windows runner
+- All quality gates pass
+
+## Files to Modify
+
+- [tests/unit/core/test_user_config.py](../../../../../tests/unit/core/test_user_config.py) - Windows-specific tests
+- [tests/e2e/features/cli.feature](../../../../../tests/e2e/features/cli.feature) - Windows scenarios if needed
+- [tests/e2e/steps/cli_steps.py](../../../../../tests/e2e/steps/cli_steps.py) - Windows step definitions if needed
+
+## Technical Notes
+
+**Windows File Permissions**:
+
+Windows uses ACLs (Access Control Lists), not Unix-style permissions. Need different approach:
+
+```python
+def test_user_config_windows_permissions():
+    """User config has restrictive ACLs on Windows."""
+    import sys
+    if sys.platform != "win32":
+        pytest.skip("Windows-only test")
+
+    from gitctx.core.user_config import UserConfig
+    config = UserConfig()
+    config.save()
+
+    # On Windows, verify file is accessible to owner
+    config_path = Path.home() / ".gitctx" / "config.yml"
+    assert config_path.exists()
+    assert os.access(config_path, os.R_OK | os.W_OK)
+
+    # Optionally check ACLs using pywin32 or similar
+    # For now, just verify file is readable/writable by owner
+```
+
+**Platform Symbol Tests**:
+
+```python
+def test_windows_cmd_uses_ascii_symbols():
+    """Windows cmd.exe uses ASCII symbols, not Unicode."""
+    import sys
+    if sys.platform != "win32":
+        pytest.skip("Windows-only test")
+
+    # Mock environment to simulate cmd.exe
+    # Verify symbols are ASCII ([OK], [X], etc.)
+```
+
+**Path Handling**:
+
+```python
+def test_windows_userprofile_path():
+    """Windows expands %USERPROFILE% correctly."""
+    import sys
+    if sys.platform != "win32":
+        pytest.skip("Windows-only test")
+
+    from gitctx.core.user_config import _get_user_home
+    home = _get_user_home()
+    assert home.exists()
+    assert "Users" in str(home)  # Typical Windows path
+```
+
+**Line Ending Tests**:
+
+```python
+def test_crlf_line_endings_in_yaml():
+    """YAML files with CRLF line endings parse correctly."""
+    # Write config with CRLF line endings
+    config_text = "search:\r\n  limit: 20\r\n"
+    config_file.write_text(config_text)
+
+    # Load config
+    config = GitCtxSettings()
+    assert config.get("search.limit") == 20
+```
+
+## Test Strategy
+
+**Windows-Specific Coverage**:
+1. File permissions (ACLs)
+2. Path handling (%USERPROFILE%, backslashes)
+3. Symbol selection (cmd.exe vs PowerShell)
+4. Line endings (CRLF)
+5. Unicode support
+
+**Approach**:
+- Use `sys.platform == "win32"` checks
+- Run in GitHub Actions Windows runner
+- Don't skip tests unnecessarily - verify actual behavior
+
+## Definition of Done
+
+- [x] Windows-specific tests added
+- [x] Tests pass in GitHub Actions Windows runner
+- [x] No unnecessary `pytest.skip` calls
+- [x] All quality gates pass
+- [x] Task marked complete in story README

--- a/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.2.md
+++ b/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.2.md
@@ -1,0 +1,583 @@
+# TASK-0001.1.2.2: Implement User and Repo Config with Pydantic Settings
+
+**Parent Story**: [STORY-0001.1.2](README.md)
+**Status**: ✅ Complete
+**Estimated Hours**: 1.0
+**Actual Hours**: 1.0
+
+## Description
+
+**GREEN Phase** - Implement user and repo configuration using Pydantic Settings to make all tests from TASK-0001.1.2.1 pass.
+
+This task creates the production-quality configuration system with:
+- Separate UserConfig and RepoConfig classes for security
+- Type-safe configuration using Pydantic models
+- Multi-source loading (YAML, environment variables, defaults)
+- User precedence: OPENAI_API_KEY > user YAML
+- Repo precedence: GITCTX_* env > repo YAML
+- Automatic API key masking with SecretStr
+- YAML file persistence to appropriate locations
+- Config init functionality for repo setup
+
+## Implementation Checklist
+
+### Dependencies
+
+**CRITICAL**: `pyyaml>=6.0.1` **ALREADY EXISTS** in pyproject.toml:30! DO NOT add it again!
+
+- [x] Add **ONLY** these to `pyproject.toml` dependencies:
+  ```toml
+  dependencies = [
+      # ...existing dependencies (typer, rich, pyyaml, shellingham)...
+      "pydantic>=2.11.0",
+      "pydantic-settings[yaml]>=2.11.0",  # [yaml] extra for YAML support
+  ]
+  ```
+- [x] Run `uv sync` to install new dependencies
+- [x] Verify installation: `uv run python -c "import pydantic_settings; print(pydantic_settings.__version__)"`
+
+**Note**: YAML parsing via `import yaml` will work immediately - pyyaml is already installed!
+
+### Core Implementation
+
+- [x] Create `src/gitctx/core/user_config.py` with:
+  - [x] `ApiKeys` model (BaseModel) - only openai field
+  - [x] `ProviderEnvSource` custom source for OPENAI_API_KEY
+  - [x] `UserConfig` (BaseSettings) with only api_keys field
+  - [x] `save()` method → `~/.gitctx/config.yml`
+- [x] Create `src/gitctx/core/repo_config.py` with:
+  - [x] `SearchSettings`, `IndexSettings`, `ModelSettings` models
+  - [x] `RepoConfig` (BaseSettings) with search, index, model fields
+  - [x] `save()` method → `.gitctx/config.yml`
+- [x] Create `src/gitctx/core/config.py` with:
+  - [x] `GitCtxSettings` aggregator class
+  - [x] `get(key)` method with routing logic
+  - [x] `set(key, value)` method with routing logic
+  - [x] `get_source(key)` method for source indicators
+  - [x] `init_repo_config()` function
+
+### Precedence Implementation
+
+- [x] Implement user config precedence:
+  1. `init_settings` - Direct initialization (highest)
+  2. `ProviderEnvSource` - OPENAI_API_KEY env var
+  3. `YamlConfigSettingsSource` - user YAML file
+  4. Field defaults (lowest)
+- [x] Implement repo config precedence:
+  1. `init_settings` - Direct initialization (highest)
+  2. `env_settings` - GITCTX_* env vars
+  3. `YamlConfigSettingsSource` - repo YAML file
+  4. Field defaults (lowest)
+
+### File Persistence
+
+- [x] Implement `UserConfig.save()` method:
+  - [x] Create `~/.gitctx/` directory if missing
+  - [x] Serialize api_keys to YAML
+  - [x] Handle SecretStr properly (reveal for saving)
+  - [x] Write to `~/.gitctx/config.yml`
+  - [x] Set file permissions (0600 - user only)
+- [x] Implement `RepoConfig.save()` method:
+  - [x] Create `.gitctx/` directory if missing
+  - [x] Serialize search, index, model to YAML
+  - [x] Write to `.gitctx/config.yml`
+  - [x] Set file permissions (0644 - safe to commit)
+- [x] Implement `init_repo_config()` function:
+  - [x] Create `.gitctx/` directory
+  - [x] Create `.gitctx/config.yml` with defaults
+  - [x] Create `.gitctx/.gitignore` with db/, logs/, *.log
+
+### Validation and Error Handling
+
+- [x] Add type validation for all settings
+- [x] Add custom validators if needed (e.g., positive integers)
+- [x] Ensure helpful error messages for validation failures
+- [x] Add error handling for malformed YAML files (catch yaml.YAMLError, show "Failed to parse config file")
+- [x] Add error handling for permission denied errors (catch PermissionError, show "Permission denied")
+- [x] Ensure error messages are clear and actionable
+
+## Code Implementation
+
+**Three separate files for security separation:**
+
+### File 1: Create `src/gitctx/core/user_config.py`
+
+**Platform Compatibility Note**: `Path.home()` is cross-platform compatible (works on Windows, macOS, Linux). On Windows, it resolves to `C:\Users\<username>`, on Unix-like systems to `/home/<username>` or `/Users/<username>`. The pathlib library handles platform-specific path separators automatically.
+
+**Testing Note**: Unit tests use the `temp_home` fixture which **already creates the `.gitctx/` subdirectory**. Override `Path.home()` with `monkeypatch.setattr("pathlib.Path.home", lambda: temp_home)` in tests.
+
+```python
+"""User-level configuration (API keys only)."""
+from pathlib import Path
+from typing import Any
+import os
+
+import yaml
+from pydantic import BaseModel, Field, SecretStr
+from pydantic_settings import (
+    BaseSettings,
+    SettingsConfigDict,
+    PydanticBaseSettingsSource,
+    YamlConfigSettingsSource,
+)
+
+
+class ApiKeys(BaseModel):
+    """API key configuration."""
+    openai: SecretStr | None = Field(default=None, description="OpenAI API key")
+
+
+class ProviderEnvSource(PydanticBaseSettingsSource):
+    """Custom source for OPENAI_API_KEY env var."""
+
+    def get_field_value(self, field, field_name):
+        # Not used - only __call__ is invoked
+        raise NotImplementedError()
+
+    def __call__(self) -> dict[str, Any]:
+        d = {}
+        if openai_key := os.getenv("OPENAI_API_KEY"):
+            d["api_keys"] = {"openai": openai_key}
+        return d
+
+
+class UserConfig(BaseSettings):
+    """User config (~/.gitctx/config.yml) - API keys only.
+
+    Precedence:
+    1. OPENAI_API_KEY env var (highest)
+    2. User YAML file
+    3. Defaults
+    """
+    api_keys: ApiKeys = Field(default_factory=ApiKeys)
+
+    model_config = SettingsConfigDict(
+        yaml_file=str(Path.home() / ".gitctx" / "config.yml"),
+        case_sensitive=False,
+        validate_default=True,
+    )
+
+    @classmethod
+    def settings_customise_sources(cls, settings_cls, init_settings, env_settings, dotenv_settings, file_secret_settings):
+        return (
+            init_settings,
+            ProviderEnvSource(settings_cls),  # OPENAI_API_KEY
+            YamlConfigSettingsSource(settings_cls),
+        )
+
+    def save(self) -> None:
+        """Save API keys to user config file."""
+        config_path = Path.home() / ".gitctx" / "config.yml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = {}
+        if self.api_keys.openai is not None:
+            data["api_keys"] = {"openai": self.api_keys.openai.get_secret_value()}
+
+        # Secure permissions
+        old_umask = os.umask(0o077)
+        try:
+            with config_path.open("w") as f:
+                yaml.dump(data, f, default_flow_style=False)
+        finally:
+            os.umask(old_umask)
+        config_path.chmod(0o600)
+```
+
+### File 2: Create `src/gitctx/core/repo_config.py`
+
+```python
+"""Repo-level configuration (team settings only)."""
+from pathlib import Path
+import os
+
+import yaml
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class SearchSettings(BaseModel):
+    limit: int = Field(default=10, gt=0, le=100)
+    rerank: bool = True
+
+
+class IndexSettings(BaseModel):
+    chunk_size: int = Field(default=1000, gt=0)
+    chunk_overlap: int = Field(default=200, ge=0)
+
+
+class ModelSettings(BaseModel):
+    embedding: str = "text-embedding-3-large"
+
+
+class RepoConfig(BaseSettings):
+    """Repo config (.gitctx/config.yml) - team settings only.
+
+    Precedence:
+    1. GITCTX_* env vars (highest)
+    2. Repo YAML file
+    3. Defaults
+
+    Default YAML content (created by config init):
+    ```yaml
+    search:
+      limit: 10
+      rerank: true
+    index:
+      chunk_size: 1000
+      chunk_overlap: 200
+    model:
+      embedding: text-embedding-3-large
+    ```
+    """
+    search: SearchSettings = Field(default_factory=SearchSettings)
+    index: IndexSettings = Field(default_factory=IndexSettings)
+    model: ModelSettings = Field(default_factory=ModelSettings)
+
+    model_config = SettingsConfigDict(
+        yaml_file=".gitctx/config.yml",
+        env_prefix="GITCTX_",
+        env_nested_delimiter="__",
+        case_sensitive=False,
+    )
+
+    def save(self) -> None:
+        """Save team settings to repo config file."""
+        config_path = Path(".gitctx/config.yml")
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = {
+            "search": self.search.model_dump(),
+            "index": self.index.model_dump(),
+            "model": self.model.model_dump(),
+        }
+
+        with config_path.open("w") as f:
+            yaml.dump(data, f, default_flow_style=False)
+        config_path.chmod(0o644)  # Safe to commit
+```
+
+### File 3: Create `src/gitctx/core/config.py`
+
+```python
+"""Aggregates user and repo config with smart routing."""
+from pathlib import Path
+from typing import Any
+import os
+
+import yaml
+from .user_config import UserConfig
+from .repo_config import RepoConfig
+
+
+class GitCtxSettings:
+    """Aggregator that routes config by key pattern.
+
+    Routes:
+    - api_keys.* → UserConfig (~/.gitctx/config.yml)
+    - search.*, index.*, model.* → RepoConfig (.gitctx/config.yml)
+    """
+
+    def __init__(self):
+        self.user = UserConfig()
+        self.repo = RepoConfig()
+
+    def get(self, key: str) -> Any:
+        """Get config value, routing by key pattern."""
+        if key.startswith("api_keys."):
+            return self._get_from_user(key)
+        else:
+            return self._get_from_repo(key)
+
+    def _get_from_user(self, key: str) -> Any:
+        """Get value from user config."""
+        parts = key.split(".")
+        current = self.user
+        for part in parts:
+            current = getattr(current, part, None)
+            if current is None:
+                return None
+
+        # Handle SecretStr
+        if hasattr(current, "get_secret_value"):
+            return current.get_secret_value()
+        return current
+
+    def _get_from_repo(self, key: str) -> Any:
+        """Get value from repo config."""
+        parts = key.split(".")
+        current = self.repo
+        for part in parts:
+            current = getattr(current, part, None)
+            if current is None:
+                return None
+        return current
+
+    def set(self, key: str, value: Any) -> None:
+        """Set config value, routing by key pattern."""
+        if key.startswith("api_keys."):
+            self._set_in_user(key, value)
+            self.user.save()  # → ~/.gitctx/config.yml
+        else:
+            self._set_in_repo(key, value)
+            self.repo.save()  # → .gitctx/config.yml
+
+    def _set_in_user(self, key: str, value: Any) -> None:
+        """Set value in user config."""
+        parts = key.split(".")
+        current = self.user
+        for part in parts[:-1]:
+            current = getattr(current, part)
+        setattr(current, parts[-1], value)
+
+    def _set_in_repo(self, key: str, value: Any) -> None:
+        """Set value in repo config."""
+        parts = key.split(".")
+        current = self.repo
+        for part in parts[:-1]:
+            current = getattr(current, part)
+        setattr(current, parts[-1], value)
+
+    def get_source(self, key: str) -> str:
+        """Get the source of a configuration value."""
+        if key.startswith("api_keys."):
+            # Check OPENAI_API_KEY
+            if key == "api_keys.openai" and os.getenv("OPENAI_API_KEY"):
+                return "(from OPENAI_API_KEY)"
+
+            # Check user config file
+            user_config_path = Path.home() / ".gitctx" / "config.yml"
+            if user_config_path.exists():
+                try:
+                    with user_config_path.open() as f:
+                        config_data = yaml.safe_load(f) or {}
+                    if "api_keys" in config_data:
+                        return "(from user config)"
+                except Exception:
+                    pass
+        else:
+            # Check GITCTX_* env vars
+            env_key = f"GITCTX_{key.upper().replace('.', '__')}"
+            if os.getenv(env_key):
+                return f"(from {env_key})"
+
+            # Check repo config file
+            repo_config_path = Path(".gitctx/config.yml")
+            if repo_config_path.exists():
+                try:
+                    with repo_config_path.open() as f:
+                        config_data = yaml.safe_load(f) or {}
+                    # Navigate nested dict
+                    parts = key.split(".")
+                    current = config_data
+                    for part in parts:
+                        if isinstance(current, dict) and part in current:
+                            current = current[part]
+                        else:
+                            return "(default)"
+                    return "(from repo config)"
+                except Exception:
+                    pass
+
+        return "(default)"
+
+
+def init_repo_config() -> None:
+    """Initialize .gitctx/ structure."""
+    gitctx_dir = Path(".gitctx")
+    gitctx_dir.mkdir(exist_ok=True)
+
+    # Create config.yml
+    config_file = gitctx_dir / "config.yml"
+    if not config_file.exists():
+        RepoConfig().save()
+
+    # Create .gitignore
+    gitignore_content = """# LanceDB vector database - never commit
+db/
+
+# Application logs - never commit
+logs/
+*.log
+"""
+    (gitctx_dir / ".gitignore").write_text(gitignore_content)
+```
+
+## Testing Requirements
+
+**CRITICAL**: Use existing fixtures from `tests/conftest.py`:
+
+### Fixture Usage Patterns
+
+**For unit tests** - Use `temp_home` fixture:
+
+```python
+def test_user_config_saves_with_permissions(temp_home, monkeypatch):
+    """Test that user config saves with correct 0600 permissions.
+
+    Uses temp_home fixture which already has .gitctx/ directory created.
+    """
+    # Override Path.home() to use temp_home
+    monkeypatch.setattr("pathlib.Path.home", lambda: temp_home)
+
+    # Create and save config
+    from gitctx.core.user_config import UserConfig
+    user_config = UserConfig()
+    user_config.api_keys.openai = "sk-test123"
+    user_config.save()
+
+    # Verify file exists (temp_home / ".gitctx" already exists!)
+    config_file = temp_home / ".gitctx" / "config.yml"
+    assert config_file.exists()
+
+    # Check permissions
+    import stat
+    mode = config_file.stat().st_mode
+    assert stat.S_IMODE(mode) == 0o600
+```
+
+**For environment variable testing** - Use `monkeypatch`:
+
+```python
+def test_openai_api_key_env_precedence(temp_home, monkeypatch):
+    """Test that OPENAI_API_KEY env var overrides user config YAML.
+
+    Uses monkeypatch for env vars and temp_home for file system isolation.
+    """
+    # Setup
+    monkeypatch.setattr("pathlib.Path.home", lambda: temp_home)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-override")
+
+    # Write config with different value (temp_home / ".gitctx" already exists!)
+    config_file = temp_home / ".gitctx" / "config.yml"
+    config_file.write_text("api_keys:\n  openai: sk-from-file\n")
+
+    # Test
+    from gitctx.core.user_config import UserConfig
+    user_config = UserConfig()
+
+    # OPENAI_API_KEY should win
+    assert user_config.api_keys.openai.get_secret_value() == "sk-env-override"
+```
+
+**For repo config testing** - Use current directory:
+
+```python
+def test_repo_config_saves_to_local_dir(tmp_path, monkeypatch):
+    """Test that repo config saves to .gitctx/ in current directory.
+
+    Uses tmp_path as working directory (NOT temp_home).
+    """
+    # Change to test directory
+    import os
+    monkeypatch.chdir(tmp_path)
+
+    # Create and save repo config
+    from gitctx.core.repo_config import RepoConfig
+    repo_config = RepoConfig()
+    repo_config.search.limit = 25
+    repo_config.save()
+
+    # Verify saved to current directory
+    config_file = tmp_path / ".gitctx" / "config.yml"
+    assert config_file.exists()
+
+    # Check content
+    content = config_file.read_text()
+    assert "limit: 25" in content
+```
+
+### After Implementation:
+
+- [x] Run unit tests: `uv run pytest tests/unit/core/test_config.py -v`
+  - All 36 core tests PASSING (GREEN) ✅
+- [x] Run BDD tests: `uv run pytest tests/e2e/ -k config -v`
+  - Config persistence scenarios PASSING ✅
+  - Precedence scenarios PASSING ✅
+  - Validation scenarios PASSING ✅
+- [x] Check coverage: `uv run pytest --cov=src/gitctx/core/config --cov-report=term-missing`
+  - user_config: 100%, repo_config: 100%, config: 90.77% ✅
+
+### Available Fixtures:
+
+From `tests/conftest.py`:
+- **`temp_home`** - Isolated HOME with `.gitctx/` already created (use for user config)
+- **`git_isolation_base`** - Security isolation env vars
+- **`cli_runner`** - In-process CLI runner for quick tests
+
+From `tests/e2e/conftest.py`:
+- **`e2e_git_isolation_env`** - Complete subprocess environment
+- **`e2e_env_factory`** - Custom environment factory
+- **`e2e_cli_runner`** - Subprocess CLI runner
+- **`e2e_git_repo`** - Real git repository
+
+## Refactoring Opportunities
+
+After tests pass (GREEN), consider:
+
+- [x] Extract YAML serialization to helper function (deferred - current implementation is clean)
+- [x] Add more custom validators if needed (Field validators with gt, ge, le sufficient)
+- [x] Optimize file I/O (caching, lazy loading) (deferred - performance meets targets)
+- [ ] Add config migration utilities for future versions (YAGNI - defer to future story)
+
+## Acceptance Criteria
+
+- [x] All unit tests from TASK-0001.1.2.1 pass
+- [x] All BDD scenarios pass
+- [x] Type validation works (invalid values rejected)
+- [x] YAML file persistence works (save and load)
+- [x] Three-tier precedence implemented correctly
+- [x] SecretStr masks API keys automatically
+- [x] File permissions set correctly (0600 user, 0644 repo)
+- [x] Coverage ≥ 85% (actual: user_config 100%, repo_config 100%, config 90.77%)
+- [x] No regressions in existing tests
+
+## Testing Commands
+
+```bash
+# Install dependencies
+uv sync
+
+# Run unit tests
+uv run pytest tests/unit/core/test_config.py -vvs
+
+# Run BDD tests
+uv run pytest tests/e2e/ -k config -vvs
+
+# Run all tests
+uv run pytest -v
+
+# Check coverage
+uv run pytest tests/unit/core/test_config.py --cov=src/gitctx/core/config --cov-report=term-missing
+
+# Manual testing
+uv run python -c "from gitctx.core.config import GitCtxSettings; s = GitCtxSettings(); print(s)"
+```
+
+## Notes
+
+- **GREEN phase**: Make all RED tests pass
+- Use Pydantic's built-in validation (don't reinvent)
+- SecretStr automatically masks in logs/repr
+- File permissions important for security (API keys)
+- `get_source()` helper enables source indicators in CLI
+- YAML library already in dependencies (pyyaml>=6.0.1)
+
+## Dependencies
+
+- [ ] TASK-0001.1.2.1 complete (tests written and failing)
+- [ ] `pydantic>=2.11.0` installed
+- [ ] `pydantic-settings>=2.11.0` installed
+- [ ] Parent story created
+
+## Security Considerations
+
+- [ ] API keys masked in string representations (SecretStr)
+- [ ] Config file has restrictive permissions (0600)
+- [ ] No secrets in logs or error messages
+- [ ] Validation prevents injection attacks
+
+---
+
+**Created**: 2025-10-04
+**Last Updated**: 2025-10-04

--- a/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.3.md
+++ b/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.3.md
@@ -1,0 +1,718 @@
+# TASK-0001.1.2.3: Integrate with CLI Commands and Add Config Init
+
+**Parent Story**: [STORY-0001.1.2](README.md)
+**Status**: ✅ Complete
+**Estimated Hours**: 2.5 (was 0.5, +2.0 for TUI compliance: progressive disclosure, symbols, tips, exit codes)
+**Actual Hours**: 2.5
+**Completion Commit**: `312d2aa` - feat(TASK-0001.1.2.3): Integrate config with CLI and add TUI compliance
+
+## Description
+
+**GREEN Phase** - Connect the UserConfig and RepoConfig to CLI commands, add config init command, and implement smart routing.
+
+This task updates `src/gitctx/cli/config.py` to use `GitCtxSettings` router, add `config init` command, and enable source indicators. All existing CLI behavior is preserved - no breaking changes.
+
+## Implementation Checklist
+
+### TUI Compliance Setup (MUST DO FIRST)
+
+- [x] **Create shared tips module** (`src/gitctx/cli/tips.py`):
+  - [x] Implement `is_first_run(command: str) -> bool` - checks `~/.gitctx/.{command}_run` marker
+  - [x] Implement `show_tip(command: str)` - displays tip box with proper platform box style
+  - [x] Define `TIPS` dict with config command tip about secure API key storage
+  - [x] Import SYMBOLS from `gitctx.cli.symbols` (reuse existing module)
+  - [x] Import Panel, ROUNDED, ASCII from rich for tip boxes
+  - [x] **Note**: This module will be reused by other commands (index, search, clear)
+
+- [x] **Import existing symbols and tips** in `src/gitctx/cli/config.py`:
+  - [x] Import `SYMBOLS` from `gitctx.cli.symbols` (already exists - DO NOT reinvent)
+  - [x] Import `is_first_run`, `show_tip` from `gitctx.cli.tips` (create new shared module)
+
+- [x] **CRITICAL: Copy CLI patterns from existing commands** (DO NOT reinvent):
+  - [x] **Verbose/Quiet flags**: Copy EXACT definitions from `src/gitctx/cli/index.py:20-31`
+  - [x] **Output mode branching**: Copy EXACT pattern from `src/gitctx/cli/index.py:67-110` (if quiet return, if verbose details, else terse)
+  - [x] **Console setup**: Copy from `index.py:10-11` (module-level `console` and `console_err`)
+  - [x] **Error formatting**: Copy from `index.py:61` (`console_err.print(f"[red]{SYMBOLS['error']}[/red] Error: {msg}")`)
+  - [x] **Exit codes**: Use `raise typer.Exit(code=N)` like `index.py:62`, `search.py:67`
+  - [x] **Symbol usage**: See `index.py:61, 76-93`, `search.py:65` for examples
+  - [x] **Reuse masking function**: Keep existing `_mask_sensitive_value()` from config.py:48-57
+
+### Add Config Init Command
+
+- [x] Add `config init` subcommand with **TUI-compliant output**:
+  - [x] Add `-v/--verbose` and `-q/--quiet` flags
+  - [x] Calls `init_repo_config()` from core
+  - [x] **Default mode (terse)**: Single line `"Initialized .gitctx/"`
+  - [x] **Verbose mode**: Multi-line with "Created..." and "Next steps:"
+  - [x] **Quiet mode**: No output on success
+  - [x] Show first-run tip after success (default/verbose only)
+  - [x] Error handling if directory already exists
+
+### Replace In-Memory Storage
+
+- [x] Update `src/gitctx/cli/config.py`:
+  - [x] Import `GitCtxSettings` from `gitctx.core.config`
+  - [x] Replace `_config_store` dict with `GitCtxSettings()` instance
+  - [x] Remove old dict-based helper functions
+  - [x] Keep all command signatures unchanged (maintain interface contract)
+
+### Update Config Set Command
+
+- [x] Modify `config_set()` with **TUI-compliant output**:
+  - [x] Add `-v/--verbose` and `-q/--quiet` flags
+  - [x] Use `GitCtxSettings.set()` for routing
+  - [x] Catch validation errors and show helpful messages
+  - [x] Catch FileNotFoundError for repo config, suggest `config init`
+  - [x] **Default mode**: `"set {key}"` (lowercase, terse)
+  - [x] **Quiet mode**: No output on success
+  - [x] Exit code 6 for permission denied errors
+
+### Update Config Get Command
+
+- [x] Modify `config_get()` with **TUI-compliant progressive disclosure**:
+  - [x] Add `-v/--verbose` and `-q/--quiet` flags
+  - [x] Use `GitCtxSettings.get()` for routing
+  - [x] Get source indicator from `settings.get_source(key)`
+  - [x] Mask SecretStr values (automatic via Pydantic)
+  - [x] **Quiet mode**: Just the masked value `"sk-...123"`
+  - [x] **Default mode (terse)**: Just the masked value `"sk-...123"` (same as quiet, git-like)
+  - [x] **Verbose mode**: `"{key} = {value} {source}"`
+  - [x] Handle None values: `"{key} is not set"`, exit code 1
+
+### Update Config List Command
+
+- [x] Modify `config_list()` with **TUI-compliant source hiding**:
+  - [x] Add `-v/--verbose` and `-q/--quiet` flags
+  - [x] Iterate over user config (api_keys)
+  - [x] Iterate over repo config (search, index, model)
+  - [x] Get source for each key
+  - [x] Mask SecretStr values
+  - [x] **Quiet mode**: Just `"{key}={value}"` (no sources)
+  - [x] **Default mode**: `"{key}={value} {source}"` for non-defaults only (hide "(default)")
+  - [x] **Verbose mode**: `"{key}={value} {source}"` for ALL values (show defaults)
+  - [x] Sort keys alphabetically
+
+### Add Validation Error Handling
+
+- [x] Catch `pydantic.ValidationError`:
+  - [x] Show field name and error message with ✗ symbol
+  - [x] Exit with code 2 (usage error per TUI_GUIDE.md)
+  - [x] Format: `"[red]{SYMBOLS['error']}[/red] Error: {field}: {error}"`
+
+- [x] Catch `PermissionError`:
+  - [x] Show clear error message with ✗ symbol
+  - [x] Exit with code 6 (permission denied per TUI_GUIDE.md)
+  - [x] Format: `"[red]{SYMBOLS['error']}[/red] Permission denied: {path}"`
+
+## Code Implementation
+
+### NEW: Create `src/gitctx/cli/tips.py`
+
+**CRITICAL**: This is a NEW shared module for first-run tips that will be reused by all commands.
+
+```python
+"""First-run tips system for gitctx CLI.
+
+Provides helpful tips to users on their first run of each command,
+then automatically hides them on subsequent runs.
+
+See TUI_GUIDE.md for tip formatting specifications.
+"""
+
+from pathlib import Path
+from rich.console import Console
+from rich.panel import Panel
+from rich.box import ROUNDED, ASCII
+
+from gitctx.cli.symbols import SYMBOLS  # Reuse existing symbols module
+
+# Create console for platform detection
+_console = Console()
+
+# Tips dictionary - add new tips here as needed
+TIPS = {
+    "config": "API keys are stored securely in ~/.gitctx/config.yml with file permissions 0600. Team settings in .gitctx/config.yml are safe to commit.",
+    # Future tips for other commands:
+    # "index": "Embeddings are stored in .gitctx/db/ and should be committed to share with your team.",
+    # "search": "Use --limit to control result count. Results are ranked by semantic similarity.",
+}
+
+
+def is_first_run(command: str) -> bool:
+    """Detect if this is user's first time running a command.
+
+    Creates a marker file at ~/.gitctx/.{command}_run to track first runs.
+    Returns True only on the very first invocation of the command.
+
+    Args:
+        command: The command name (e.g., "config", "index", "search")
+
+    Returns:
+        True if this is the first run, False otherwise
+
+    Example:
+        >>> if is_first_run("config"):
+        ...     show_tip("config")
+    """
+    marker_file = Path.home() / ".gitctx" / f".{command}_run"
+    if not marker_file.exists():
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        marker_file.touch()
+        return True
+    return False
+
+
+def show_tip(command: str) -> None:
+    """Display a tip box for the specified command.
+
+    Uses platform-appropriate box style (ASCII for Windows cmd.exe,
+    Unicode for modern terminals).
+
+    Args:
+        command: The command name to show a tip for
+
+    Example:
+        >>> show_tip("config")
+        💡 Tip
+        ╭────────────────────────────────────────╮
+        │ API keys are stored securely in ...    │
+        ╰────────────────────────────────────────╯
+    """
+    tip = TIPS.get(command)
+    if not tip:
+        return
+
+    # Use ASCII box for legacy Windows cmd.exe, Unicode for modern terminals
+    box_style = ASCII if _console.legacy_windows else ROUNDED
+    tip_icon = SYMBOLS["tip"]
+
+    panel = Panel(
+        tip,
+        title=f"{tip_icon} Tip",
+        title_align="left",
+        box=box_style,
+        border_style="blue",
+        expand=False,
+    )
+
+    _console.print()
+    _console.print(panel)
+    _console.print()
+```
+
+### Update `src/gitctx/cli/config.py`
+
+```python
+"""Config command for gitctx CLI."""
+
+import sys
+from pydantic import ValidationError
+import typer
+from rich.console import Console
+
+from gitctx.core.config import GitCtxSettings
+from gitctx.cli.symbols import SYMBOLS  # Reuse existing symbols module
+from gitctx.cli.tips import is_first_run, show_tip  # Reuse tips system
+
+console = Console()
+
+# Create a sub-app for config commands
+config_app = typer.Typer(help="Manage gitctx configuration")
+
+
+def register(app: typer.Typer) -> None:
+    """Register the config command group with the CLI app."""
+    app.add_typer(config_app, name="config")
+
+
+def _set_nested_value(settings: GitCtxSettings, key: str, value: str) -> None:
+    """Set a nested configuration value using dot notation.
+
+    Args:
+        settings: GitCtxSettings instance
+        key: Dot-notation key (e.g., "api_keys.openai")
+        value: Value to set
+
+    Raises:
+        ValidationError: If value fails Pydantic validation
+        AttributeError: If key path is invalid
+    """
+    parts = key.split(".")
+    current = settings
+
+    # Navigate to parent
+    for part in parts[:-1]:
+        current = getattr(current, part)
+
+    # Set the final field
+    setattr(current, parts[-1], value)
+
+
+def _get_nested_value(settings: GitCtxSettings, key: str) -> str | None:
+    """Get a nested configuration value using dot notation.
+
+    Args:
+        settings: GitCtxSettings instance
+        key: Dot-notation key (e.g., "api_keys.openai")
+
+    Returns:
+        Value as string, or None if not set
+    """
+    parts = key.split(".")
+    current = settings
+
+    try:
+        for part in parts:
+            current = getattr(current, part)
+
+        # Handle SecretStr
+        if hasattr(current, "get_secret_value"):
+            return current.get_secret_value()
+
+        # Handle None
+        if current is None:
+            return None
+
+        return str(current)
+    except AttributeError:
+        return None
+
+
+def _mask_value(key: str, value: str) -> str:
+    """Mask sensitive values for display.
+
+    Args:
+        key: Configuration key
+        value: Value to potentially mask
+
+    Returns:
+        Masked value if sensitive, otherwise original value
+    """
+    # Check if this is an API key field
+    if "key" in key.lower() and len(value) > 6:
+        return f"{value[:3]}...{value[-3:]}"
+    return value
+
+
+@config_app.command("init")
+def config_init(
+    verbose: bool = typer.Option(False, "-v", "--verbose", help="Show detailed output"),
+    quiet: bool = typer.Option(False, "-q", "--quiet", help="Suppress all output except errors"),
+) -> None:
+    """
+    Initialize repo-level configuration.
+
+    Creates:
+      - .gitctx/config.yml (team settings)
+      - .gitctx/.gitignore (protects db/ and logs/)
+
+    Run this once per repository before setting repo-level config.
+    """
+    try:
+        from gitctx.core.config import init_repo_config
+        init_repo_config()
+
+        if not quiet:
+            # Default: terse single-line (TUI_GUIDE.md compliance)
+            console.print("Initialized .gitctx/")
+
+            if verbose:
+                # Verbose: detailed output with next steps
+                console.print("  Created .gitctx/config.yml")
+                console.print("  Created .gitctx/.gitignore")
+                console.print("\nNext steps:")
+                console.print("  1. Set your API key: gitctx config set api_keys.openai sk-...")
+                console.print("  2. Index your repo: gitctx index")
+                console.print("  3. Commit to share: git add .gitctx/ && git commit -m 'chore: Add gitctx embeddings'")
+
+            # First-run tip (only once)
+            if is_first_run("config"):
+                show_tip("config")
+
+    except FileExistsError:
+        if not quiet:
+            console.print(f"[yellow]{SYMBOLS['warning']}[/yellow] .gitctx/ already initialized")
+    except PermissionError as e:
+        console.print(f"[red]{SYMBOLS['error']}[/red] Permission denied: {e}", file=sys.stderr)
+        raise typer.Exit(6)
+    except Exception as e:
+        console.print(f"[red]{SYMBOLS['error']}[/red] Error: {e}", file=sys.stderr)
+        raise typer.Exit(1)
+
+
+@config_app.command("set")
+def config_set(
+    key: str = typer.Argument(..., help="Configuration key (supports dot notation)"),
+    value: str = typer.Argument(..., help="Configuration value"),
+    verbose: bool = typer.Option(False, "-v", "--verbose", help="Show detailed output"),
+    quiet: bool = typer.Option(False, "-q", "--quiet", help="Suppress all output except errors"),
+) -> None:
+    """
+    Set a configuration value.
+
+    Examples:
+
+        $ gitctx config set api_keys.openai sk-abc123
+        $ gitctx config set search.limit 20
+    """
+    try:
+        # Load settings, update value, save
+        settings = GitCtxSettings()
+        _set_nested_value(settings, key, value)
+        settings.save()
+
+        if not quiet:
+            # Default: terse lowercase confirmation (TUI_GUIDE.md compliance)
+            console.print(f"set {key}")
+
+    except ValidationError as e:
+        # Show validation errors with symbol (exit code 2 per TUI_GUIDE.md)
+        for error in e.errors():
+            field = ".".join(str(loc) for loc in error["loc"])
+            console.print(f"[red]{SYMBOLS['error']}[/red] Error: {field}: {error['msg']}", file=sys.stderr)
+        raise typer.Exit(2)
+    except PermissionError as e:
+        console.print(f"[red]{SYMBOLS['error']}[/red] Permission denied: {e}", file=sys.stderr)
+        raise typer.Exit(6)
+    except AttributeError:
+        console.print(f"[red]{SYMBOLS['error']}[/red] Error: Unknown configuration key: {key}", file=sys.stderr)
+        raise typer.Exit(2)
+    except Exception as e:
+        console.print(f"[red]{SYMBOLS['error']}[/red] Error: {e}", file=sys.stderr)
+        raise typer.Exit(1)
+
+
+@config_app.command("get")
+def config_get(
+    key: str = typer.Argument(..., help="Configuration key to retrieve"),
+    verbose: bool = typer.Option(False, "-v", "--verbose", help="Show key name and source"),
+    quiet: bool = typer.Option(False, "-q", "--quiet", help="Output value only, no formatting"),
+) -> None:
+    """
+    Get a configuration value.
+
+    Environment variables take precedence over config file values.
+
+    Examples:
+
+        $ gitctx config get api_keys.openai
+        sk-...123
+
+        $ gitctx config get api_keys.openai --verbose
+        api_keys.openai = sk-...123 (from user config)
+    """
+    try:
+        settings = GitCtxSettings()
+        value = _get_nested_value(settings, key)
+
+        if value is None:
+            console.print(f"{key} is not set")
+            raise typer.Exit(1)
+
+        # Mask sensitive values
+        masked = _mask_value(key, value)
+
+        if quiet:
+            # Quiet: just the value (for scripting)
+            console.print(masked)
+        elif verbose:
+            # Verbose: key = value (source)
+            source = settings.get_source(key)
+            console.print(f"{key} = {masked} {source}")
+        else:
+            # Default: just the value (terse, git-like per TUI_GUIDE.md)
+            console.print(masked)
+
+    except AttributeError:
+        console.print(f"[red]{SYMBOLS['error']}[/red] Error: Unknown configuration key: {key}", file=sys.stderr)
+        raise typer.Exit(2)
+
+
+@config_app.command("list")
+def config_list(
+    verbose: bool = typer.Option(False, "-v", "--verbose", help="Show sources for all values including defaults"),
+    quiet: bool = typer.Option(False, "-q", "--quiet", help="Suppress formatting, show key=value only"),
+) -> None:
+    """
+    List all configuration settings.
+
+    Shows current configuration with sensitive values masked.
+
+    Examples:
+
+        $ gitctx config list
+        api_keys.openai=sk-...123 (from user config)
+        search.limit=10
+
+        $ gitctx config list --verbose
+        api_keys.openai=sk-...123 (from user config)
+        search.limit=10 (default)
+        model.embedding=text-embedding-3-large (default)
+    """
+    settings = GitCtxSettings()
+
+    # Flatten nested models to dot notation
+    items = []
+
+    # api_keys.*
+    if settings.api_keys.openai is not None:
+        value = settings.api_keys.openai.get_secret_value()
+        masked = _mask_value("api_keys.openai", value)
+        source = settings.get_source("api_keys.openai")
+        items.append(("api_keys.openai", masked, source))
+
+    # search.*
+    for field in ["limit", "rerank"]:
+        value = getattr(settings.search, field)
+        source = settings.get_source(f"search.{field}")
+        items.append((f"search.{field}", str(value), source))
+
+    # index.*
+    for field in ["chunk_size", "chunk_overlap"]:
+        value = getattr(settings.index, field)
+        source = settings.get_source(f"index.{field}")
+        items.append((f"index.{field}", str(value), source))
+
+    # model.*
+    for field in ["embedding"]:
+        value = getattr(settings.model, field)
+        source = settings.get_source(f"model.{field}")
+        items.append((f"model.{field}", str(value), source))
+
+    # Sort and print
+    if not items:
+        console.print("No configuration set")
+        return
+
+    for key, value, source in sorted(items):
+        if quiet:
+            # Quiet: just key=value
+            console.print(f"{key}={value}")
+        elif verbose:
+            # Verbose: show ALL sources (including defaults)
+            console.print(f"{key}={value} {source}")
+        else:
+            # Default: only show source if non-default (TUI_GUIDE.md compliance)
+            if source and "(default)" not in source.lower():
+                console.print(f"{key}={value} {source}")
+            else:
+                console.print(f"{key}={value}")
+```
+
+## Testing Requirements
+
+**CRITICAL**: Use existing CLI fixtures for testing:
+
+### Fixture Usage for CLI Tests
+
+**For unit tests** - Use `cli_runner` fixture:
+
+```python
+def test_config_set_validates_types(cli_runner, temp_home, monkeypatch):
+    """Test that config set validates type correctness.
+
+    Uses cli_runner for in-process CLI testing (faster than subprocess).
+    Uses temp_home for isolated file system.
+    """
+    from gitctx.cli.main import app
+
+    # Setup isolated home
+    monkeypatch.setattr("pathlib.Path.home", lambda: temp_home)
+
+    # Try to set invalid value
+    result = cli_runner.invoke(app, ["config", "set", "search.limit", "invalid"])
+
+    # Should fail with validation error
+    assert result.exit_code == 1
+    assert "validation error" in result.output.lower()
+
+def test_config_get_shows_source(cli_runner, temp_home, monkeypatch):
+    """Test that config get shows source indicator.
+
+    Uses cli_runner and temp_home fixtures.
+    """
+    from gitctx.cli.main import app
+
+    # Setup
+    monkeypatch.setattr("pathlib.Path.home", lambda: temp_home)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test123")
+
+    # Get config value
+    result = cli_runner.invoke(app, ["config", "get", "api_keys.openai"])
+
+    # Should show value and source
+    assert result.exit_code == 0
+    assert "sk-...123" in result.output
+    assert "(from OPENAI_API_KEY)" in result.output
+```
+
+**For E2E tests** - Use `e2e_cli_runner` fixture:
+
+```python
+def test_config_persistence_across_invocations(e2e_cli_runner, e2e_git_isolation_env):
+    """Test that config persists across separate CLI invocations.
+
+    Uses e2e_cli_runner for true subprocess isolation.
+    e2e_git_isolation_env provides isolated HOME with .gitctx/ directory.
+    """
+    from gitctx.cli.main import app
+
+    # Set config in first invocation
+    result1 = e2e_cli_runner.invoke(app, ["config", "set", "search.limit", "25"])
+    assert result1.exit_code == 0
+
+    # Get config in second invocation (separate process)
+    result2 = e2e_cli_runner.invoke(app, ["config", "get", "search.limit"])
+    assert result2.exit_code == 0
+    assert "25" in result2.output
+```
+
+### Fixture Selection Guide
+
+**Use `cli_runner`** (from `tests/conftest.py`) when:
+- Testing CLI command logic in-process
+- Need fast test execution
+- Don't need true subprocess isolation
+- Testing validation, output formatting
+
+**Use `e2e_cli_runner`** (from `tests/e2e/conftest.py`) when:
+- Testing true persistence across invocations
+- Need complete subprocess isolation
+- Testing environment variable handling
+- Testing file system operations
+
+### After Implementation:
+
+- [x] Run CLI unit tests: `uv run pytest tests/unit/cli/test_config.py -v`
+  - ✅ All 28 unit tests passing
+  - ✅ Tests for validation, source indicators all passing
+- [x] Run BDD tests: `uv run pytest tests/e2e/ -k config -v`
+  - ✅ All 19 config scenarios passing
+- [x] Manual testing completed:
+  ```bash
+  # Set and get - ✅ Working
+  # Environment variable precedence - ✅ Working
+  # Validation - ✅ Working
+  # List - ✅ Working
+  ```
+
+## Output Format Changes
+
+**config get** - Adds source indicator (new):
+```bash
+# Before (STORY-0001.1.1):
+$ gitctx config get api_keys.openai
+sk-...123
+
+# After (this task):
+$ gitctx config get api_keys.openai
+api_keys.openai = sk-...123 (from config file)
+```
+
+**config list** - Adds source indicators for API keys (new):
+```bash
+# Before:
+api_keys.openai=sk-...123
+search.limit=10
+
+# After:
+api_keys.openai=sk-...123 (from OPENAI_API_KEY)
+search.limit=10
+```
+
+**config set** - Unchanged:
+```bash
+Set api_keys.openai
+```
+
+## Acceptance Criteria
+
+- [x] `config set` saves to YAML file
+- [x] `config get` shows value with source indicator
+- [x] `config list` shows all settings with sources
+- [x] Validation errors caught and displayed helpfully
+- [x] SecretStr values automatically masked
+- [x] No breaking changes to CLI interface
+- [x] All BDD scenarios pass (19/19 passing)
+- [x] All unit tests pass (28/28 passing)
+- [x] Coverage maintained at ≥ 85% (actual: 95.32%)
+
+## Interface Compatibility (with STORY-0001.1.1)
+
+**Preserved behaviors** - All 78 tests from STORY-0001.1.1 must pass:
+- ✅ `config set` output format unchanged
+- ✅ `config get` shows masked values
+- ✅ `config list` shows all settings
+- ✅ Dot notation works
+- ✅ Environment variables override config
+
+**Enhanced behaviors** (additions, not breaking changes):
+- ➕ Persistent storage (survives restarts)
+- ➕ Source indicators in output
+- ➕ Type validation with helpful errors
+- ➕ Provider env var (`OPENAI_API_KEY`) support
+
+## Testing Commands
+
+```bash
+# Run unit tests
+uv run pytest tests/unit/cli/test_config.py -v
+
+# Run BDD tests
+uv run pytest tests/e2e/ -k config -v
+
+# Run all tests
+uv run pytest -v
+
+# Manual testing
+uv run gitctx config set api_keys.openai sk-test123
+uv run gitctx config get api_keys.openai
+uv run gitctx config list
+
+# Test precedence
+export OPENAI_API_KEY=sk-provider789
+export GITCTX_API_KEYS__OPENAI=sk-gitctx456
+uv run gitctx config get api_keys.openai  # Should show api_keys.openai = sk-...789 (from OPENAI_API_KEY)
+
+# Test validation
+uv run gitctx config set search.limit invalid  # Should error
+```
+
+## Available Fixtures
+
+From `tests/conftest.py`:
+- **`temp_home`** - Isolated HOME with `.gitctx/` already created
+- **`git_isolation_base`** - Security isolation env vars
+- **`cli_runner`** - In-process CLI runner (fast, good for unit tests)
+
+From `tests/e2e/conftest.py`:
+- **`e2e_git_isolation_env`** - Complete subprocess environment
+- **`e2e_cli_runner`** - Subprocess CLI runner (true isolation)
+- **`e2e_env_factory`** - Custom environment factory
+- **`e2e_git_repo`** - Real git repository
+
+From `tests/e2e/steps/cli_steps.py`:
+- **`context`** - Stores test data between steps (already exists!)
+
+## Notes
+
+- **GREEN phase**: Connect Config to CLI, tests should pass
+- Maintain CLI interface contract (all existing tests must pass)
+- Source indicators are additive enhancements (not breaking)
+- Validation errors improve UX (not a breaking change)
+- File persistence is transparent to users
+- **Use existing fixtures**: 8 comprehensive fixtures available, no new ones needed
+- **`cli_runner` vs `e2e_cli_runner`**: Use cli_runner for fast unit tests, e2e_cli_runner for true subprocess isolation
+- **`temp_home` bonus**: Already has `.gitctx/` directory created!
+
+## Dependencies
+
+- [x] TASK-0001.1.2.2 complete (Config class implemented)
+- [x] All tests from TASK-0001.1.2.1 passing
+- [x] `src/gitctx/core/config.py` exists and tested
+
+---
+
+**Created**: 2025-10-04
+**Last Updated**: 2025-10-05
+**Completed**: 2025-10-05

--- a/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.4.md
+++ b/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.4.md
@@ -1,0 +1,82 @@
+# TASK-0001.1.2.4: Security Hardening - Permission Checks
+
+**Parent Story**: [STORY-0001.1.2](README.md)
+**Status**: ✅ Complete
+**Estimated Hours**: 0.5
+**Actual Hours**: 0.5
+**Completion Commit**: fec762e (fix: Address PR review - security, docs, UX)
+
+## Objective
+
+Add runtime permission checks for user config file to warn users if their `~/.gitctx/config.yml` has insecure permissions (> 0600), protecting API keys from unauthorized access.
+
+## Context
+
+PR #4 review feedback identified that while we set 0600 permissions on save, we don't check permissions on load. Users could accidentally chmod the file later, exposing their API keys.
+
+## Implementation Checklist
+
+- [ ] Add permission check in `UserConfig.settings_customise_sources()`
+- [ ] Check if `~/.gitctx/config.yml` exists and has permissions > 0600
+- [ ] Display warning using Rich console: `[yellow]⚠️ User config has insecure permissions (current: 0XXX, should be 0600)[/yellow]`
+- [ ] Add unit test in `tests/unit/core/test_user_config.py` for permission check
+- [ ] Add BDD scenario in `tests/e2e/features/cli.feature`: "User config with insecure permissions shows warning"
+- [ ] Run quality gates: `uv run poe fix && uv run poe quality`
+- [ ] Manual testing: Create config with 0644, verify warning displays
+
+## Acceptance Criteria
+
+- User config with permissions > 0600 triggers warning on any config read operation
+- Warning shows current permissions and recommended permissions (0600)
+- Warning is non-blocking (doesn't prevent reading config)
+- Unit test verifies permission check logic
+- BDD scenario verifies end-to-end warning display
+- All quality gates pass
+
+## Files to Modify
+
+- [src/gitctx/core/user_config.py](../../../../../src/gitctx/core/user_config.py) - Add check in `settings_customise_sources()`
+- [tests/unit/core/test_user_config.py](../../../../../tests/unit/core/test_user_config.py) - Add permission test
+- [tests/e2e/features/cli.feature](../../../../../tests/e2e/features/cli.feature) - Add BDD scenario
+
+## Technical Notes
+
+```python
+# In settings_customise_sources(), before returning sources:
+yaml_file = _get_user_home() / ".gitctx" / "config.yml"
+if yaml_file.exists():
+    stat = yaml_file.stat()
+    # On Unix: st_mode & 0o777 gives permission bits
+    # Check if group or others have any permissions
+    if stat.st_mode & 0o077:  # Group (o70) or others (o07) have access
+        from rich.console import Console
+        console = Console()
+        current_perms = oct(stat.st_mode)[-3:]
+        console.print(f"[yellow]⚠️ User config has insecure permissions (current: {current_perms}, should be 0600)[/yellow]")
+```
+
+## Test Strategy
+
+**Unit Test** (`test_user_config_permission_check`):
+- Create temp config with 0644 permissions
+- Mock Path.home() to point to temp location
+- Capture console output
+- Assert warning is displayed with correct permission values
+
+**BDD Scenario**:
+```gherkin
+Scenario: User config with insecure permissions shows warning
+  Given user config exists with permissions 0644
+  When I run "gitctx config get api_keys.openai"
+  Then the output should contain "⚠️ User config has insecure permissions"
+  And the output should contain "current: 644, should be 0600"
+```
+
+## Definition of Done
+
+- [ ] Code implemented and passes ruff/mypy
+- [ ] Unit test added and passing
+- [ ] BDD scenario added and passing
+- [ ] Manual testing completed
+- [ ] All quality gates pass
+- [ ] Task marked complete in story README

--- a/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.5.md
+++ b/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.5.md
@@ -1,0 +1,94 @@
+# TASK-0001.1.2.5: Code Documentation Improvements
+
+**Parent Story**: [STORY-0001.1.2](README.md)
+**Status**: ✅ Complete
+**Estimated Hours**: 0.25
+**Actual Hours**: 0.25
+**Completion Commit**: fec762e (fix: Address PR review - security, docs, UX)
+
+## Objective
+
+Add comprehensive docstrings to config path navigation methods to clarify recursive path access behavior and improve code maintainability.
+
+## Context
+
+PR #4 review feedback noted that `_get_from_user()` and `_get_from_repo()` methods lack docstrings explaining their recursive path navigation logic (e.g., how "api_keys.openai" becomes nested attribute access).
+
+## Implementation Checklist
+
+- [ ] Add docstring to `_get_from_user()` in `src/gitctx/core/config.py`
+- [ ] Add docstring to `_get_from_repo()` in `src/gitctx/core/config.py`
+- [ ] Document recursive path navigation mechanism
+- [ ] Document return behavior for missing paths
+- [ ] Document SecretStr unwrapping behavior in `_get_from_user()`
+- [ ] Run quality gates: `uv run poe fix && uv run poe quality`
+
+## Acceptance Criteria
+
+- Docstrings explain input format (e.g., "api_keys.openai")
+- Docstrings explain how path is split and traversed
+- Docstrings explain return values (including None for missing paths)
+- Docstrings explain SecretStr special handling
+- All quality gates pass
+
+## Files to Modify
+
+- [src/gitctx/core/config.py](../../../../../src/gitctx/core/config.py) - Add/improve docstrings
+
+## Technical Notes
+
+**Example docstring for `_get_from_user()`**:
+
+```python
+def _get_from_user(self, key: str) -> Any:
+    """Get value from user config by navigating nested attributes.
+
+    Recursively traverses the user config object using dot-separated path segments.
+    Automatically unwraps Pydantic SecretStr values to return plain strings.
+
+    Args:
+        key: Dot-separated path to config value (e.g., "api_keys.openai")
+
+    Returns:
+        The config value at the specified path, or None if path doesn't exist.
+        SecretStr values are automatically unwrapped via get_secret_value().
+
+    Examples:
+        >>> config._get_from_user("api_keys.openai")
+        "sk-abc123..."  # Unwrapped from SecretStr
+
+        >>> config._get_from_user("api_keys.nonexistent")
+        None
+    """
+```
+
+**Example docstring for `_get_from_repo()`**:
+
+```python
+def _get_from_repo(self, key: str) -> Any:
+    """Get value from repo config by navigating nested attributes.
+
+    Recursively traverses the repo config object using dot-separated path segments.
+
+    Args:
+        key: Dot-separated path to config value (e.g., "search.limit")
+
+    Returns:
+        The config value at the specified path, or None if path doesn't exist.
+
+    Examples:
+        >>> config._get_from_repo("search.limit")
+        10
+
+        >>> config._get_from_repo("search.nonexistent")
+        None
+    """
+```
+
+## Definition of Done
+
+- [ ] Docstrings added to both methods
+- [ ] Docstrings include Args, Returns, and Examples sections
+- [ ] Code passes ruff/mypy checks
+- [ ] All quality gates pass
+- [ ] Task marked complete in story README

--- a/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.6.md
+++ b/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.6.md
@@ -1,0 +1,130 @@
+# TASK-0001.1.2.6: User-Friendly Validation Errors
+
+**Parent Story**: [STORY-0001.1.2](README.md)
+**Status**: ✅ Complete
+**Estimated Hours**: 0.5
+**Actual Hours**: 0.5
+**Completion Commit**: fec762e (fix: Address PR review - security, docs, UX)
+
+## Objective
+
+Translate Pydantic ValidationError exceptions into user-friendly error messages so developers see clear guidance instead of technical stack traces.
+
+## Context
+
+PR #4 review feedback noted that Pydantic validation errors show technical stack traces when users provide invalid config values. We should catch these and translate them to friendly messages.
+
+## Implementation Checklist
+
+- [ ] Add `ValidationError` exception handler in `src/gitctx/cli/config.py`
+- [ ] Create error translation function to map Pydantic errors to user messages
+- [ ] Handle common validation cases:
+  - Type errors (e.g., string instead of int)
+  - Range errors (e.g., value outside gt/le bounds)
+  - Required field errors
+- [ ] Add unit tests in `tests/unit/cli/test_config.py` for validation error translation
+- [ ] Verify existing BDD scenario: "Config validation catches invalid values" shows user-friendly output
+- [ ] Run quality gates: `uv run poe fix && uv run poe quality`
+
+## Acceptance Criteria
+
+- Invalid config values show clear, actionable error messages
+- Error messages explain what was wrong and what's expected
+- Technical Pydantic details are hidden from users
+- Exit code 2 used for validation errors (usage error)
+- Unit tests verify error translation for common cases
+- Existing BDD scenario passes with friendly error text
+
+## Files to Modify
+
+- [src/gitctx/cli/config.py](../../../../../src/gitctx/cli/config.py) - Add validation error handler
+- [tests/unit/cli/test_config.py](../../../../../tests/unit/cli/test_config.py) - Add validation error tests
+
+## Technical Notes
+
+**Error Translation Function**:
+
+```python
+from pydantic import ValidationError
+
+def translate_validation_error(e: ValidationError, key: str, value: Any) -> str:
+    """Translate Pydantic ValidationError to user-friendly message.
+
+    Args:
+        e: The ValidationError from Pydantic
+        key: Config key that was being set
+        value: Value that failed validation
+
+    Returns:
+        User-friendly error message
+    """
+    # Get first error (most relevant)
+    error = e.errors()[0]
+    error_type = error["type"]
+
+    if error_type == "int_parsing":
+        return f"Invalid value '{value}' for {key} - expected a number"
+    elif error_type in ("greater_than", "less_than_equal"):
+        # Extract constraint from error message
+        return f"Invalid value '{value}' for {key} - must be between allowed range"
+    elif error_type == "missing":
+        return f"Missing required field: {key}"
+    else:
+        # Generic fallback
+        return f"Invalid value '{value}' for {key} - {error['msg']}"
+```
+
+**Usage in config.py set command**:
+
+```python
+@app.command()
+def set(key: str, value: str):
+    """Set configuration value."""
+    try:
+        settings = GitCtxSettings()
+        settings.set(key, value)
+        console.print(f"[green]✓[/green] set {key}")
+    except ValidationError as e:
+        error_msg = translate_validation_error(e, key, value)
+        console.print(f"[red]✗[/red] {error_msg}")
+        raise typer.Exit(2)  # Exit code 2 for validation/usage errors
+```
+
+## Test Strategy
+
+**Unit Tests** (`tests/unit/cli/test_config.py`):
+
+```python
+def test_set_invalid_type_shows_friendly_error():
+    """Setting non-integer for search.limit shows friendly error."""
+    # Test that ValidationError is caught and translated
+
+def test_set_out_of_range_shows_friendly_error():
+    """Setting value outside range shows friendly error."""
+    # Test range validation error translation
+
+def test_validation_error_exits_with_code_2():
+    """Validation errors exit with code 2."""
+    # Verify exit code for validation failures
+```
+
+**BDD Scenario** (verify existing scenario shows friendly text):
+
+```gherkin
+Scenario: Config validation catches invalid values
+  Given I run "gitctx config init"
+  When I run "gitctx config set search.limit invalid"
+  Then the exit code should be 2
+  And the output should contain "Invalid value 'invalid' for search.limit - expected a number"
+  And the output should NOT contain "ValidationError"
+  And the output should NOT contain "Traceback"
+```
+
+## Definition of Done
+
+- [ ] Error translation function implemented
+- [ ] ValidationError handler added to set command
+- [ ] Unit tests added and passing
+- [ ] BDD scenario updated/verified with friendly error text
+- [ ] All quality gates pass
+- [ ] Task marked complete in story README

--- a/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.7.md
+++ b/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.7.md
@@ -1,0 +1,92 @@
+# TASK-0001.1.2.7: Fix get_source() Complexity Violation
+
+**Parent Story**: [STORY-0001.1.2](README.md)
+**Status**: ✅ Complete
+**Estimated Hours**: 0.25
+**Actual Hours**: 0.25
+
+## Objective
+
+Extract helper method from `GitCtxSettings.get_source()` to reduce cyclomatic complexity from 11 to ≤10, passing ruff complexity checks.
+
+## Context
+
+The config module (460 lines, 19 functions) is clean and well-organized. Only issue: `get_source()` method has cyclomatic complexity of 11 (threshold is 10). This needs a focused fix, not architectural refactoring.
+
+**Current violation:**
+```
+src/gitctx/core/config.py:XXX:X: C901 `get_source` is too complex (11 > 10)
+```
+
+## Implementation Checklist
+
+- [x] Identify the specific conditional logic causing complexity >10
+- [x] Extract one helper method to reduce complexity
+- [x] Ensure behavior unchanged (same source detection logic)
+- [x] Run quality gates: `uv run poe fix && uv run poe quality`
+- [x] Verify cyclomatic complexity ≤10
+
+## Acceptance Criteria
+
+- `ruff check` passes with no C901 violations
+- `get_source()` cyclomatic complexity ≤10
+- Source detection behavior unchanged (all tests pass)
+- No other code changes needed (focused fix only)
+
+## Files to Modify
+
+- [src/gitctx/core/config.py](../../../../../src/gitctx/core/config.py) - Extract helper from `get_source()`
+
+## Technical Notes
+
+**Approach** (extract conditional logic):
+
+Current structure likely has multiple `if/elif` chains for source detection:
+```python
+def get_source(self, key: str) -> str:
+    if key.startswith("api_keys."):
+        if env_var_set:
+            return "OPENAI_API_KEY"
+        elif user_file_exists:
+            return "user config"
+        # ... more conditions
+    else:
+        if gitctx_env_set:
+            return f"GITCTX_{key.upper()}"
+        elif repo_file_exists:
+            return "repo config"
+        # ... more conditions
+```
+
+**Fix**: Extract helper method:
+```python
+def _get_api_key_source(self, key: str) -> str:
+    """Determine source for API key configuration."""
+    if env_var_set:
+        return "OPENAI_API_KEY"
+    elif user_file_exists:
+        return "user config"
+    # ... (reduces complexity by splitting logic)
+
+def get_source(self, key: str) -> str:
+    if key.startswith("api_keys."):
+        return self._get_api_key_source(key)
+    else:
+        return self._get_repo_setting_source(key)
+```
+
+This reduces `get_source()` complexity while maintaining identical behavior.
+
+## Test Strategy
+
+**Verification**:
+- All existing unit tests pass (no behavior change)
+- `uv run ruff check src/gitctx/core/config.py` shows no C901 violations
+- No new tests needed (internal refactor only)
+
+## Definition of Done
+
+- [ ] Cyclomatic complexity ≤10 for `get_source()`
+- [ ] All existing tests pass
+- [ ] All quality gates pass
+- [ ] Task marked complete in story README

--- a/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.8.md
+++ b/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.8.md
@@ -1,0 +1,150 @@
+# TASK-0001.1.2.8: Add Essential Edge Case Tests
+
+**Parent Story**: [STORY-0001.1.2](README.md)
+**Status**: ✅ Complete
+**Estimated Hours**: 0.25
+**Actual Hours**: 0.25
+
+## Objective
+
+Add focused edge case tests for real-world scenarios: Unicode handling (international users), auto-directory creation (first-time users), and file corruption (editor crashes).
+
+## Context
+
+Current tests cover happy paths well. Need minimal edge case coverage for:
+1. **Unicode** - Users worldwide have non-ASCII in API keys, model names
+2. **First-time UX** - Missing `~/.gitctx/` directory should auto-create
+3. **File corruption** - Editor crashes/disk full should show clear errors
+
+**NOT testing**: Concurrent writes (CLI is single-process), DOS attacks (user controls files), YAML bombs (safe_load handles), deep nesting (Pydantic prevents).
+
+## Implementation Checklist
+
+- [x] Add Unicode tests (3 tests):
+  - API key with Chinese characters: `api_keys.openai = "密钥-sk-abc123"`
+  - Model name with emoji: `model.embedding = "text-embedding-🌍-large"`
+  - RTL text in API key: `api_keys.openai = "sk-العربية123"`
+- [x] Add auto-create directory test (1 test):
+  - `save()` creates `~/.gitctx/` if missing (with parents)
+- [x] Add file corruption tests (2 tests):
+  - Truncated YAML file → ValidationError with clear message
+  - Malformed YAML → ValidationError with helpful message
+- [x] Run quality gates: All passed (ruff check, ruff format, mypy, pytest - 192 tests, 94.59% coverage)
+
+## Acceptance Criteria
+
+- Unicode characters in config values handled correctly
+- Missing parent directories created automatically
+- Malformed YAML shows clear, actionable error messages
+- All quality gates pass
+- Coverage maintained ≥ 85%
+
+## Files to Modify
+
+- [tests/unit/core/test_user_config.py](../../../../../tests/unit/core/test_user_config.py) - Unicode + auto-create tests
+- [tests/unit/core/test_repo_config.py](../../../../../tests/unit/core/test_repo_config.py) - Corruption tests
+
+## Technical Notes
+
+**Unicode Tests** (test_user_config.py):
+
+```python
+class TestEdgeCasesUnicode:
+    """Test Unicode handling - real scenario: international users."""
+
+    def test_unicode_chinese_in_api_key(self, isolated_env):
+        """API key can contain Chinese characters."""
+        config_file = isolated_env / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: 密钥-sk-abc123\n")
+
+        config = UserConfig()
+        assert config.api_keys.openai.get_secret_value() == "密钥-sk-abc123"
+
+    def test_unicode_emoji_in_model_name(self, tmp_path, monkeypatch):
+        """Model name can contain emoji."""
+        monkeypatch.chdir(tmp_path)
+        config = RepoConfig()
+        config.model.embedding = "text-embedding-🌍-large"
+        config.save()
+
+        config2 = RepoConfig()
+        assert config2.model.embedding == "text-embedding-🌍-large"
+
+    def test_unicode_rtl_in_api_key(self, isolated_env):
+        """API key can contain RTL (Arabic) text."""
+        config_file = isolated_env / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: sk-العربية123\n")
+
+        config = UserConfig()
+        assert config.api_keys.openai.get_secret_value() == "sk-العربية123"
+```
+
+**Auto-Create Directory Test** (test_user_config.py):
+
+```python
+class TestFilesystemEdgeCases:
+    """Test filesystem edge cases - real scenario: first-time user."""
+
+    def test_save_creates_missing_parent_directories(self, tmp_path, monkeypatch):
+        """save() creates ~/.gitctx/ if missing."""
+        new_home = tmp_path / "nonexistent" / "user" / "home"
+        monkeypatch.setenv("HOME", str(new_home))
+
+        config = UserConfig()
+        config.api_keys.openai = SecretStr("sk-test123")
+        config.save()
+
+        config_file = new_home / ".gitctx" / "config.yml"
+        assert config_file.exists()
+```
+
+**File Corruption Tests** (test_repo_config.py):
+
+```python
+class TestFileCorruption:
+    """Test file corruption - real scenario: editor crash, disk full."""
+
+    def test_truncated_yaml_shows_clear_error(self, tmp_path, monkeypatch):
+        """Truncated YAML shows clear error message."""
+        monkeypatch.chdir(tmp_path)
+        config_file = tmp_path / ".gitctx" / "config.yml"
+        config_file.parent.mkdir()
+        config_file.write_text("search:\n  lim")  # Truncated mid-value
+
+        with pytest.raises(Exception) as exc:
+            RepoConfig()
+        assert "parse" in str(exc.value).lower() or "yaml" in str(exc.value).lower()
+
+    def test_malformed_yaml_shows_clear_error(self, tmp_path, monkeypatch):
+        """Malformed YAML shows helpful error message."""
+        monkeypatch.chdir(tmp_path)
+        config_file = tmp_path / ".gitctx" / "config.yml"
+        config_file.parent.mkdir()
+        config_file.write_text("search:\n- wrong_type")  # List instead of dict
+
+        with pytest.raises(Exception):
+            RepoConfig()
+```
+
+## Test Strategy
+
+**Focus**: Real-world edge cases only
+
+1. **Unicode** - International users (Chinese, Arabic, emoji)
+2. **First-time UX** - Auto-create directories
+3. **File corruption** - Editor crashes, disk full
+
+**Explicitly NOT testing**:
+- Concurrent writes (CLI is single-process)
+- DOS attacks (user controls files, pointless)
+- YAML bombs (PyYAML safe_load handles)
+- Deep nesting (Pydantic schema prevents)
+- Invalid UTF-8 (extremely rare, truncated test similar)
+
+## Definition of Done
+
+- [ ] 6 focused edge case tests added
+- [ ] All tests passing
+- [ ] Coverage maintained ≥ 85%
+- [ ] All quality gates pass
+- [ ] Task marked complete in story README

--- a/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.9.md
+++ b/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.9.md
@@ -1,0 +1,181 @@
+# TASK-0001.1.2.9: Create Configuration User Documentation
+
+**Parent Story**: [STORY-0001.1.2](README.md)
+**Status**: ✅ Complete
+**Estimated Hours**: 1.0
+**Actual Hours**: 1.0
+
+## Objective
+
+Create comprehensive user-facing documentation for gitctx configuration system covering all options, environment variables, security best practices, and troubleshooting.
+
+## Context
+
+Users need clear documentation explaining how to configure gitctx, what options are available, security considerations, and how to solve common problems.
+
+## Implementation Checklist
+
+- [x] Create `docs/configuration.md` with complete guide
+- [x] Document all config options with descriptions and examples
+- [x] Create environment variable reference table
+- [x] Add security best practices section
+- [x] Add troubleshooting guide for common errors
+- [x] Document cross-platform differences (Windows/macOS/Linux)
+- [x] Add examples for common use cases
+- [x] Link from main README if appropriate
+
+## Acceptance Criteria
+
+- Complete configuration reference exists
+- All config options documented with examples
+- Environment variables listed in reference table
+- Security guidance is clear and actionable
+- Troubleshooting covers common scenarios
+- Platform differences explained
+- Documentation is clear and well-organized
+
+## File to Create
+
+- [docs/configuration.md](../../../../../docs/configuration.md) - New user documentation
+
+## Technical Notes
+
+**Documentation Structure**:
+
+```markdown
+# Configuration Guide
+
+## Overview
+Brief introduction to gitctx configuration system.
+
+## Quick Start
+Common configuration examples to get started quickly.
+
+## Configuration Files
+
+### User Config (~/.gitctx/config.yml)
+Stores API keys and user preferences.
+
+### Repo Config (.gitctx/config.yml)
+Stores team settings, safe to commit.
+
+## Configuration Options
+
+### API Keys
+- `api_keys.openai` - OpenAI API key for embeddings (string)
+  - Example: `sk-abc123...`
+  - Security: Never commit to repo
+
+### Search Settings
+- `search.limit` - Max results to return (integer, 1-100, default: 10)
+  - Example: `20`
+- `search.context_lines` - Lines of context (integer, 0-10, default: 3)
+
+### Index Settings
+- `index.chunk_size` - Token chunk size (integer, 100-2000, default: 500)
+- `index.overlap` - Chunk overlap (integer, 0-500, default: 50)
+
+### Model Settings
+- `model.embedding` - Embedding model (string, default: "text-embedding-3-small")
+- `model.temperature` - Temperature (float, 0.0-2.0, default: 0.0)
+
+## Environment Variables
+
+| Variable | Config Key | Description |
+|----------|-----------|-------------|
+| `OPENAI_API_KEY` | `api_keys.openai` | OpenAI API key (user config) |
+| `GITCTX_SEARCH__LIMIT` | `search.limit` | Search result limit (repo config) |
+| `GITCTX_SEARCH__CONTEXT_LINES` | `search.context_lines` | Context lines (repo config) |
+
+**Precedence**: Environment variables override config files.
+
+## Security Best Practices
+
+### API Key Safety
+1. **Never commit API keys**: User config is `.gitignore`d
+2. **Use environment variables**: `OPENAI_API_KEY` in production
+3. **Check file permissions**: `~/.gitctx/config.yml` should be `0600`
+4. **Rotate keys regularly**: Update in case of exposure
+
+### File Permissions
+- User config: `0600` (read/write owner only)
+- Repo config: `0644` (readable by all, writable by owner)
+
+## Cross-Platform Notes
+
+### Windows
+- User config: `%USERPROFILE%\.gitctx\config.yml`
+- File permissions use ACLs (not Unix-style)
+- Use PowerShell or cmd.exe for commands
+
+### macOS/Linux
+- User config: `~/.gitctx/config.yml`
+- File permissions: Standard Unix (600/644)
+- Use terminal for commands
+
+## Troubleshooting
+
+### "Permission denied" error
+**Problem**: Config file has wrong permissions or is read-only.
+**Solution**: Check file permissions: `ls -la ~/.gitctx/config.yml`
+
+### "Invalid value" error
+**Problem**: Config value doesn't match expected type.
+**Solution**: Check type (int vs string) and range constraints.
+
+### "Config file not found"
+**Problem**: Config file doesn't exist.
+**Solution**: Run `gitctx config init` to create `.gitctx/`
+
+### API key not working
+**Problem**: API key not loaded correctly.
+**Solution**:
+1. Check file exists: `ls ~/.gitctx/config.yml`
+2. Verify permissions: Should be `600`
+3. Try environment variable: `export OPENAI_API_KEY=sk-...`
+
+## Examples
+
+### Basic Setup
+\`\`\`bash
+# Initialize repo config
+gitctx config init
+
+# Set API key
+gitctx config set api_keys.openai sk-abc123...
+
+# Set search limit
+gitctx config set search.limit 20
+\`\`\`
+
+### Team Configuration
+\`\`\`bash
+# In .gitctx/config.yml (safe to commit)
+search:
+  limit: 25
+  context_lines: 5
+
+index:
+  chunk_size: 1000
+  overlap: 100
+\`\`\`
+
+### Environment Variables
+\`\`\`bash
+# Set API key via environment
+export OPENAI_API_KEY=sk-abc123...
+
+# Override search limit for this session
+export GITCTX_SEARCH__LIMIT=50
+\`\`\`
+```
+
+## Definition of Done
+
+- [x] `docs/configuration.md` created with all sections
+- [x] All config options documented
+- [x] Environment variables listed
+- [x] Security guidance included
+- [x] Troubleshooting section complete
+- [x] Examples provided
+- [x] Task marked complete in story README

--- a/docs/tickets/INIT-0001/README.md
+++ b/docs/tickets/INIT-0001/README.md
@@ -3,7 +3,7 @@
 **Timeline**: Q4 2025
 **Status**: 🚧 In Progress
 **Owner**: Core Team
-**Progress**: ██░░░░░░░░ ~15% (STORY-0001.1.0 complete)
+**Progress**: ███░░░░░░░ ~33% (EPIC-0001.1 complete - 10/10 story points, 1 of 3 epics done)
 
 ## Objective
 
@@ -20,7 +20,7 @@ Build the core functionality users need to search their codebase intelligently. 
 
 | ID | Title | Status | Progress | Owner |
 |----|-------|--------|----------|-------|
-| [EPIC-0001.1](EPIC-0001.1/README.md) | CLI Foundation | 🟡 In Progress | ████░░░░░░ 38% | Core Team |
+| [EPIC-0001.1](EPIC-0001.1/README.md) | CLI Foundation | ✅ Complete | ██████████ 100% | Core Team |
 | [EPIC-0001.2](EPIC-0001.2/README.md) | Real Indexing | 🔵 Not Started | ░░░░░░░░░░ 0% | - |
 | [EPIC-0001.3](EPIC-0001.3/README.md) | Vector Search | 🔵 Not Started | ░░░░░░░░░░ 0% | - |
 
@@ -75,11 +75,14 @@ Build the core functionality users need to search their codebase intelligently. 
 
 ### CLI Foundation (EPIC-0001.1)
 
-- ⬜ Main CLI structure with Typer
-- ⬜ Config command for API keys
-- ⬜ Help system and documentation
-- ⬜ Error handling and user feedback
-- ⬜ Progress indicators with Rich
+- ✅ Main CLI structure with Typer
+- 🟡 Config command with persistent storage (STORY-0001.1.2 in progress)
+- ✅ Help system and documentation
+- ✅ Error handling and user feedback
+- ✅ Progress indicators with Rich
+
+**Progress**: 8/10 story points complete (80%)
+**Remaining**: STORY-0001.1.2 - Real configuration with 5 polish tasks remaining (caching, refactoring, edge cases, docs, Windows CI)
 
 ### Real Indexing (EPIC-0001.2)
 
@@ -163,10 +166,15 @@ The MVP is complete when:
 
 ## Next Steps
 
-1. Complete EPIC-0001.1 remaining tasks
-2. Start EPIC-0001.2 implementation
-3. Set up CI/CD pipeline
-4. Prepare for alpha testing
+1. **STORY-0001.1.2**: Complete 5 remaining polish tasks
+   - TASK-0001.1.2.7: Add Config Caching Layer (1.0h)
+   - TASK-0001.1.2.8: Refactor GitCtxSettings for Maintainability (1.5h)
+   - TASK-0001.1.2.9: Add Edge Case Tests (0.5h)
+   - TASK-0001.1.2.10: Create Configuration User Documentation (1.0h)
+   - TASK-0001.1.2.11: Add Windows CI Integration Tests (0.5h)
+   - Completes EPIC-0001.1 at 100% (10/10 points)
+2. **EPIC-0001.2**: Start real indexing implementation
+3. Prepare for alpha testing with working index + search
 
 ## Notes
 
@@ -177,6 +185,6 @@ The MVP is complete when:
 
 ---
 
-**Created**: 2025-09-28  
-**Last Updated**: 2025-09-28  
+**Created**: 2025-09-28
+**Last Updated**: 2025-10-05
 **Review Schedule**: Weekly during active development

--- a/docs/vision/ROADMAP.md
+++ b/docs/vision/ROADMAP.md
@@ -39,21 +39,28 @@ Build the core functionality users need to search their codebase intelligently.
 
 **Epics**:
 
-- EPIC-0001.1: CLI Foundation - 🟡 In Progress (~80% - 8/10 story points complete)
+- EPIC-0001.1: CLI Foundation - ✅ Complete (100% - 10/10 story points)
   - ✅ STORY-0001.1.0: Development Environment Setup (5 points)
   - ✅ STORY-0001.1.1: CLI Framework Setup (3 points) - **Code Review: 9.5/10 (Production-Ready)**
-    - 78 tests passing, 98.82% coverage
+    - 82 tests passing, 98.28% coverage
     - Zero critical/major issues found
     - Ready for next stories to build on this foundation
+  - ✅ STORY-0001.1.2: Real Configuration Management (5 points) - **Complete**
+    - Pydantic Settings for type-safe config
+    - User/repo config separation with security hardening
+    - Progressive disclosure TUI compliance
+    - 19 BDD scenarios passing, 94.55% coverage
+    - Windows CI integration complete
 - EPIC-0001.2: Real Indexing - 🔵 Not Started
 - EPIC-0001.3: Vector Search - 🔵 Not Started
 
 **Key Deliverables:**
 
 - ✅ Complete CLI with all commands (mocked implementations) - **Production-Ready**
-- ⬜ OpenAI embedding generation
-- ⬜ LanceDB vector search
-- ⬜ Basic context assembly
+- ✅ Persistent configuration with Pydantic Settings (STORY-0001.1.2) - **Complete**
+- ⬜ OpenAI embedding generation (EPIC-0001.2)
+- ⬜ LanceDB vector search (EPIC-0001.3)
+- ⬜ Basic context assembly (EPIC-0001.3)
 
 **Success Criteria:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "rich>=13.7.0",
     "pyyaml>=6.0.1",
     "shellingham>=1.5.0",
+    "pydantic>=2.11.0",
+    "pydantic-settings[yaml]>=2.11.0",
 ]
 
 [project.optional-dependencies]
@@ -83,6 +85,12 @@ ignore = [
 quote-style = "double"
 indent-style = "space"
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    "ARG001",  # Unused function argument (mocks often don't use args)
+    "ARG002",  # Unused method argument (fixtures are often unused in test body)
+]
+
 [tool.mypy]
 python_version = "3.11"
 strict = true
@@ -115,6 +123,7 @@ addopts = [
     "--cov-report=term-missing:skip-covered",
     "--cov-report=html",
     "--cov-report=xml",
+    "--color=yes",
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
@@ -191,3 +200,136 @@ sequence = [
     { cmd = "pre-commit run --all-files" },
 ]
 help = "Install and test pre-commit hooks"
+
+# === GitHub PR Review Comment Management ===
+
+[tool.poe.tasks.pr-reply]
+shell = """
+gh api graphql -f query='
+mutation {
+  addPullRequestReviewThreadReply(input: {
+    pullRequestReviewThreadId: "'$THREAD_ID'"
+    body: "'$BODY'"
+  }) {
+    comment {
+      id
+    }
+  }
+}'
+"""
+help = "Reply to a PR review comment thread. Requires: THREAD_ID, BODY env vars"
+
+[tool.poe.tasks.pr-resolve]
+shell = """
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {
+    threadId: "'$THREAD_ID'"
+  }) {
+    thread {
+      id
+      isResolved
+    }
+  }
+}'
+"""
+help = "Resolve a PR review comment thread. Requires: THREAD_ID env var"
+
+[tool.poe.tasks.pr-find-thread]
+shell = """
+gh api graphql -f query='
+query {
+  repository(owner: "'${OWNER:-gitctx-ai}'", name: "'${REPO:-gitctx}'") {
+    pullRequest(number: '${PR_NUMBER}') {
+      reviewThreads(first: 50) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes {
+              databaseId
+              body
+            }
+          }
+        }
+      }
+    }
+  }
+}' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.comments.nodes[0].databaseId == '${COMMENT_ID}') | {threadId: .id, isResolved, commentBody: .comments.nodes[0].body}'
+"""
+help = "Find thread ID by comment ID. Requires: PR_NUMBER, COMMENT_ID env vars. Optional: OWNER, REPO"
+
+[tool.poe.tasks.pr-address-comment]
+shell = """
+# Complete workflow: find thread ID, reply, and resolve
+# Automatically gets correct GitHub username from 'gh api user'
+
+# Get authenticated user's GitHub username
+GH_USERNAME=$(gh api user --jq '.login')
+
+echo "Step 1: Finding thread ID for comment ${COMMENT_ID}..."
+THREAD_ID=$(gh api graphql -f query='
+query {
+  repository(owner: "'${OWNER:-gitctx-ai}'", name: "'${REPO:-gitctx}'") {
+    pullRequest(number: '${PR_NUMBER}') {
+      reviewThreads(first: 50) {
+        nodes {
+          id
+          comments(first: 1) {
+            nodes {
+              databaseId
+            }
+          }
+        }
+      }
+    }
+  }
+}' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.comments.nodes[0].databaseId == '${COMMENT_ID}') | .id' | tr -d '\\n')
+
+if [ -z "$THREAD_ID" ]; then
+  echo "Error: Could not find thread for comment ${COMMENT_ID}"
+  exit 1
+fi
+
+echo "Found thread: $THREAD_ID"
+
+# Step 2: Reply to the thread (automatically add "On behalf of @username" footer)
+echo "Step 2: Adding reply (on behalf of @$GH_USERNAME)..."
+
+# Construct the full reply body with attribution
+FULL_REPLY="$REPLY_BODY
+
+---
+*On behalf of @$GH_USERNAME*"
+
+gh api graphql -f query='
+mutation {
+  addPullRequestReviewThreadReply(input: {
+    pullRequestReviewThreadId: "'$THREAD_ID'"
+    body: "'$(echo "$FULL_REPLY" | sed 's/"/\\\\"/g' | sed 's/$/\\n/g' | tr -d '\\n')'"
+  }) {
+    comment {
+      id
+    }
+  }
+}' > /dev/null
+
+echo "Reply added successfully"
+
+# Step 3: Resolve the thread
+echo "Step 3: Resolving thread..."
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {
+    threadId: "'$THREAD_ID'"
+  }) {
+    thread {
+      id
+      isResolved
+    }
+  }
+}' > /dev/null
+
+echo "✅ Comment ${COMMENT_ID} addressed: replied and resolved"
+"""
+help = "Complete workflow to address a PR comment (auto-adds username). Requires: PR_NUMBER, COMMENT_ID, REPLY_BODY env vars. Optional: OWNER, REPO"

--- a/src/gitctx/cli/config.py
+++ b/src/gitctx/cli/config.py
@@ -1,15 +1,17 @@
 """Config command for gitctx CLI."""
 
-import os
 from typing import Any
 
 import typer
+from pydantic import ValidationError
 from rich.console import Console
 
-console = Console()
+from gitctx.cli.symbols import SYMBOLS
+from gitctx.cli.tips import is_first_run, show_tip
+from gitctx.core.config import GitCtxSettings, init_repo_config
 
-# In-memory storage for mock configuration (NO file I/O for testing isolation)
-_config_store: dict[str, Any] = {}
+console = Console()
+console_err = Console(stderr=True)
 
 # Create a sub-app for config commands
 config_app = typer.Typer(help="Manage gitctx configuration")
@@ -20,135 +22,286 @@ def register(app: typer.Typer) -> None:
     app.add_typer(config_app, name="config")
 
 
-def _parse_dot_notation(key: str) -> list[str]:
-    """Parse dot notation into nested keys."""
-    return key.split(".")
+def _translate_validation_error(e: ValidationError, key: str, value: str) -> str:
+    """Translate Pydantic ValidationError to user-friendly message.
+
+    Args:
+        e: The ValidationError from Pydantic
+        key: Config key that was being set
+        value: Value that failed validation
+
+    Returns:
+        User-friendly error message explaining the validation failure
+    """
+    # Get first error (most relevant)
+    if not e.errors():
+        return f"Invalid value '{value}' for {key}"
+
+    error = e.errors()[0]
+    error_type = error["type"]
+    msg = error.get("msg", "")
+
+    # Translate common Pydantic error types to user-friendly messages
+    if "int" in error_type.lower() or "integer" in msg.lower():
+        return f"Invalid value '{value}' for {key} - expected a number"
+    elif "greater_than" in error_type:
+        # Extract the constraint if available
+        ctx = error.get("ctx", {})
+        min_val = ctx.get("gt", ctx.get("ge", ""))
+        if min_val:
+            return f"Invalid value '{value}' for {key} - must be greater than {min_val}"
+        return f"Invalid value '{value}' for {key} - value too small"
+    elif "less_than" in error_type:
+        ctx = error.get("ctx", {})
+        max_val = ctx.get("lt", ctx.get("le", ""))
+        if max_val:
+            return f"Invalid value '{value}' for {key} - must be less than {max_val}"
+        return f"Invalid value '{value}' for {key} - value too large"
+    elif "bool" in error_type.lower():
+        return f"Invalid value '{value}' for {key} - expected true or false"
+    elif "missing" in error_type:
+        return f"Missing required field: {key}"
+    else:
+        # Generic fallback - use Pydantic's message but make it friendlier
+        return f"Invalid value '{value}' for {key} - {msg.lower()}"
 
 
-def _get_nested(data: dict[str, Any], keys: list[str]) -> Any:
-    """Get value from nested dict using key path."""
-    current = data
-    for k in keys:
-        if not isinstance(current, dict) or k not in current:
-            return None
-        current = current[k]
-    return current
+@config_app.command("init")
+def config_init(
+    verbose: bool = typer.Option(False, "-v", "--verbose", help="Show detailed output"),
+    quiet: bool = typer.Option(False, "-q", "--quiet", help="Suppress all output except errors"),
+) -> None:
+    """Initialize repo-level configuration.
 
+    Creates:
+      - .gitctx/config.yml (team settings)
+      - .gitctx/.gitignore (protects db/ and logs/)
 
-def _set_nested(data: dict[str, Any], keys: list[str], value: str) -> None:
-    """Set value in nested dict using key path."""
-    current = data
-    for k in keys[:-1]:
-        if k not in current:
-            current[k] = {}
-        current = current[k]
-    current[keys[-1]] = value
+    Run this once per repository before setting repo-level config.
+    """
+    try:
+        init_repo_config()
 
+        if not quiet:
+            # Default: terse single-line (TUI_GUIDE.md compliance)
+            console.print("Initialized .gitctx/")
 
-def _mask_sensitive_value(key: str, value: str) -> str:
-    """Mask sensitive values like API keys."""
-    # Check if this is an API key (starts with common prefixes) and long enough to mask
-    if (
-        any(key.endswith(f".{provider}") for provider in ["openai", "anthropic", "cohere"])
-        and len(value) > 6
-    ):
-        # Show first 3 and last 3 characters: sk-...123
-        return f"{value[:3]}...{value[-3:]}"
-    return value
+            if verbose:
+                # Verbose: detailed output with next steps
+                console.print("  Created .gitctx/config.yml")
+                console.print("  Created .gitctx/.gitignore")
+                console.print("\nNext steps:")
+                console.print("  1. Set your API key: gitctx config set api_keys.openai sk-...")
+                console.print("  2. Index your repo: gitctx index")
+                console.print(
+                    "  3. Commit to share: git add .gitctx/ && git commit -m 'chore: Add gitctx embeddings'"
+                )
 
+            # First-run tip (only once)
+            if is_first_run("config"):
+                show_tip("config")
 
-def _get_env_value(key: str) -> str | None:
-    """Get value from environment variable if it exists."""
-    # Map config keys to environment variable names
-    env_mapping = {
-        "api_keys.openai": "OPENAI_API_KEY",
-        "api_keys.anthropic": "ANTHROPIC_API_KEY",
-    }
-    env_var = env_mapping.get(key)
-    if env_var:
-        return os.environ.get(env_var)
-    return None
+    except FileExistsError:
+        if not quiet:
+            console.print(f"[yellow]{SYMBOLS['warning']}[/yellow] .gitctx/ already initialized")
+    except PermissionError as e:
+        console_err.print(f"[red]{SYMBOLS['error']}[/red] Permission denied: {e}")
+        raise typer.Exit(6) from e
+    except Exception as e:
+        console_err.print(f"[red]{SYMBOLS['error']}[/red] Error: {e}")
+        raise typer.Exit(1) from e
 
 
 @config_app.command("set")
 def config_set(
     key: str = typer.Argument(..., help="Configuration key (supports dot notation)"),
     value: str = typer.Argument(..., help="Configuration value"),
+    verbose: bool = typer.Option(False, "-v", "--verbose", help="Show detailed output"),
+    quiet: bool = typer.Option(False, "-q", "--quiet", help="Suppress all output except errors"),
 ) -> None:
-    """
-    Set a configuration value.
+    """Set a configuration value.
 
     Examples:
 
         $ gitctx config set api_keys.openai sk-abc123
         $ gitctx config set search.limit 20
     """
-    keys = _parse_dot_notation(key)
-    _set_nested(_config_store, keys, value)
-    console.print(f"Set {key}")
+    try:
+        # Load settings, update value, save
+        settings = GitCtxSettings()
+        settings.set(key, value)
+
+        if quiet:
+            # Quiet: no output
+            pass
+        elif verbose:
+            # Verbose: show which config file was updated
+            config_location = "user config" if key.startswith("api_keys.") else "repo config"
+            config_path = (
+                "~/.gitctx/config.yml" if key.startswith("api_keys.") else ".gitctx/config.yml"
+            )
+            console.print(f"set {key} in {config_location} ({config_path})")
+        else:
+            # Default: terse lowercase confirmation (TUI_GUIDE.md compliance)
+            console.print(f"set {key}")
+
+    except ValidationError as e:
+        # Show user-friendly validation errors (exit code 2 per TUI_GUIDE.md)
+        friendly_msg = _translate_validation_error(e, key, value)
+        console_err.print(f"[red]{SYMBOLS['error']}[/red] {friendly_msg}")
+        raise typer.Exit(2) from e
+    except PermissionError as e:
+        console_err.print(f"[red]{SYMBOLS['error']}[/red] Permission denied: {e}")
+        raise typer.Exit(6) from e
+    except AttributeError as e:
+        console_err.print(f"[red]{SYMBOLS['error']}[/red] Error: Unknown configuration key: {key}")
+        raise typer.Exit(2) from e
+    except FileNotFoundError as e:
+        console_err.print(
+            f"[red]{SYMBOLS['error']}[/red] Error: Run 'gitctx config init' first to create .gitctx/"
+        )
+        raise typer.Exit(1) from e
+    except Exception as e:
+        console_err.print(f"[red]{SYMBOLS['error']}[/red] Error: {e}")
+        raise typer.Exit(1) from e
 
 
 @config_app.command("get")
 def config_get(
     key: str = typer.Argument(..., help="Configuration key to retrieve"),
+    verbose: bool = typer.Option(False, "-v", "--verbose", help="Show key name and source"),
+    quiet: bool = typer.Option(False, "-q", "--quiet", help="Output value only, no formatting"),
 ) -> None:
-    """
-    Get a configuration value.
+    """Get a configuration value.
 
     Environment variables take precedence over config file values.
 
     Examples:
 
         $ gitctx config get api_keys.openai
-        $ gitctx config get search.limit
+        sk-...123
+
+        $ gitctx config get api_keys.openai --verbose
+        api_keys.openai = sk-...123 (from user config)
     """
-    # Check environment variable first (takes precedence)
-    env_value = _get_env_value(key)
-    if env_value:
-        masked = _mask_sensitive_value(key, env_value)
-        console.print(f"{key} = {masked} (from environment)")
-        return
+    try:
+        settings = GitCtxSettings()
 
-    # Get from config store
-    keys = _parse_dot_notation(key)
-    value = _get_nested(_config_store, keys)
+        # For API keys, get the MaskedSecretStr object directly for auto-masking
+        if key.startswith("api_keys."):
+            # Navigate to the actual field to preserve MaskedSecretStr
+            parts = key.split(".")
+            current: Any = settings.user
+            for part in parts:
+                current = getattr(current, part, None)
+                if current is None:
+                    console.print(f"{key} is not set")
+                    raise typer.Exit(1)
+            value_for_display = str(current)  # Auto-masks via MaskedSecretStr.__str__()
+        else:
+            # For non-secret values, use normal get
+            value = settings.get(key)
+            if value is None:
+                console.print(f"{key} is not set")
+                raise typer.Exit(1)
+            value_for_display = str(value)
 
-    if value is None:
-        console.print(f"{key} is not set")
-        return
+        if quiet:
+            # Quiet: just the value (for scripting)
+            console.print(value_for_display)
+        elif verbose:
+            # Verbose: key = value (source)
+            source = settings.get_source(key)
+            console.print(f"{key} = {value_for_display} {source}")
+        else:
+            # Default: just the value (terse, git-like per TUI_GUIDE.md)
+            console.print(value_for_display)
 
-    masked = _mask_sensitive_value(key, value)
-    console.print(f"{key} = {masked}")
+    except AttributeError as e:
+        console_err.print(f"[red]{SYMBOLS['error']}[/red] Error: Unknown configuration key: {key}")
+        raise typer.Exit(2) from e
+    except Exception as e:
+        # Catch YAML parsing errors and other config loading errors
+        error_msg = str(e).lower()
+        if "yaml" in error_msg or "parsing" in error_msg:
+            console_err.print(f"[red]{SYMBOLS['error']}[/red] Failed to parse config file: {e}")
+        else:
+            console_err.print(f"[red]{SYMBOLS['error']}[/red] Error: {e}")
+        raise typer.Exit(1) from e
 
 
 @config_app.command("list")
-def config_list() -> None:
-    """
-    List all configuration settings.
+def config_list(
+    verbose: bool = typer.Option(
+        False,
+        "-v",
+        "--verbose",
+        help="Show sources for all values including defaults",
+    ),
+    quiet: bool = typer.Option(
+        False, "-q", "--quiet", help="Suppress formatting, show key=value only"
+    ),
+) -> None:
+    """List all configuration settings.
 
     Shows current configuration with sensitive values masked.
 
-    Example:
+    Examples:
 
         $ gitctx config list
+        api_keys.openai=sk-...123 (from user config)
+        search.limit=10
+
+        $ gitctx config list --verbose
+        api_keys.openai=sk-...123 (from user config)
+        search.limit=10 (default)
+        model.embedding=text-embedding-3-large (default)
     """
-    if not _config_store:
+    settings = GitCtxSettings()
+
+    # Flatten nested models to dot notation
+    items = []
+
+    # api_keys.*
+    if settings.user.api_keys.openai is not None:
+        # MaskedSecretStr auto-masks via __str__()
+        masked = str(settings.user.api_keys.openai)
+        source = settings.get_source("api_keys.openai")
+        items.append(("api_keys.openai", masked, source))
+
+    # search.*
+    for field in ["limit", "rerank"]:
+        value = getattr(settings.repo.search, field)
+        source = settings.get_source(f"search.{field}")
+        items.append((f"search.{field}", str(value), source))
+
+    # index.*
+    for field in ["chunk_size", "chunk_overlap"]:
+        value = getattr(settings.repo.index, field)
+        source = settings.get_source(f"index.{field}")
+        items.append((f"index.{field}", str(value), source))
+
+    # model.*
+    for field in ["embedding"]:
+        value = getattr(settings.repo.model, field)
+        source = settings.get_source(f"model.{field}")
+        items.append((f"model.{field}", str(value), source))
+
+    # Sort and print
+    if not items:
         console.print("No configuration set")
         return
 
-    def _flatten_dict(d: dict[str, Any], prefix: str = "") -> dict[str, Any]:
-        """Flatten nested dict to dot notation."""
-        items = {}
-        for k, v in d.items():
-            new_key = f"{prefix}.{k}" if prefix else k
-            if isinstance(v, dict):
-                items.update(_flatten_dict(v, new_key))
+    for key, value, source in sorted(items):
+        if quiet:
+            # Quiet: just key=value
+            console.print(f"{key}={value}")
+        elif verbose:
+            # Verbose: show ALL sources (including defaults)
+            console.print(f"{key}={value} {source}")
+        else:
+            # Default: only show source if non-default (TUI_GUIDE.md compliance)
+            if source and "(default)" not in source.lower():
+                console.print(f"{key}={value} {source}")
             else:
-                items[new_key] = v
-        return items
-
-    flat = _flatten_dict(_config_store)
-
-    for key, value in sorted(flat.items()):
-        masked = _mask_sensitive_value(key, str(value))
-        console.print(f"{key} = {masked}")
+                console.print(f"{key}={value}")

--- a/src/gitctx/cli/tips.py
+++ b/src/gitctx/cli/tips.py
@@ -1,0 +1,103 @@
+"""First-run tips system for gitctx CLI.
+
+Provides helpful tips to users on their first run of each command,
+then automatically hides them on subsequent runs.
+
+See TUI_GUIDE.md for tip formatting specifications.
+"""
+
+import os
+from pathlib import Path
+
+from rich.box import ASCII, ROUNDED
+from rich.console import Console
+from rich.panel import Panel
+
+from gitctx.cli.symbols import SYMBOLS
+
+
+def _get_user_home() -> Path:
+    """Get user home directory, respecting HOME env var.
+
+    On Unix, Path.home() respects HOME environment variable.
+    On Windows, Path.home() ignores HOME and uses USERPROFILE.
+    This helper ensures HOME is used when set (critical for testing).
+
+    Returns:
+        Path: User home directory
+    """
+    return Path(os.environ.get("HOME", str(Path.home())))
+
+
+# Create console for platform detection
+_console = Console()
+
+# Tips dictionary - add new tips here as needed
+TIPS = {
+    "config": "API keys are stored securely in ~/.gitctx/config.yml with file permissions 0600. Team settings in .gitctx/config.yml are safe to commit.",
+    # Future tips for other commands:
+    # "index": "Embeddings are stored in .gitctx/db/ and should be committed to share with your team.",
+    # "search": "Use --limit to control result count. Results are ranked by semantic similarity.",
+}
+
+
+def is_first_run(command: str) -> bool:
+    """Detect if this is user's first time running a command.
+
+    Creates a marker file at ~/.gitctx/.{command}_run to track first runs.
+    Returns True only on the very first invocation of the command.
+
+    Args:
+        command: The command name (e.g., "config", "index", "search")
+
+    Returns:
+        True if this is the first run, False otherwise
+
+    Example:
+        >>> if is_first_run("config"):
+        ...     show_tip("config")
+    """
+    marker_file = _get_user_home() / ".gitctx" / f".{command}_run"
+    if not marker_file.exists():
+        marker_file.parent.mkdir(parents=True, exist_ok=True)
+        marker_file.touch()
+        return True
+    return False
+
+
+def show_tip(command: str) -> None:
+    """Display a tip box for the specified command.
+
+    Uses platform-appropriate box style (ASCII for Windows cmd.exe,
+    Unicode for modern terminals).
+
+    Args:
+        command: The command name to show a tip for
+
+    Example:
+        >>> show_tip("config")
+        💡 Tip
+        ╭────────────────────────────────────────╮
+        │ API keys are stored securely in ...    │
+        ╰────────────────────────────────────────╯
+    """
+    tip = TIPS.get(command)
+    if not tip:
+        return
+
+    # Use ASCII box for legacy Windows cmd.exe, Unicode for modern terminals
+    box_style = ASCII if _console.legacy_windows else ROUNDED
+    tip_icon = SYMBOLS["tip"]
+
+    panel = Panel(
+        tip,
+        title=f"{tip_icon} Tip",
+        title_align="left",
+        box=box_style,
+        border_style="blue",
+        expand=False,
+    )
+
+    _console.print()
+    _console.print(panel)
+    _console.print()

--- a/src/gitctx/core/config.py
+++ b/src/gitctx/core/config.py
@@ -1,0 +1,215 @@
+"""Aggregates user and repo config with smart routing."""
+
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .repo_config import RepoConfig
+from .user_config import UserConfig
+
+
+class GitCtxSettings:
+    """Aggregator that routes config by key pattern.
+
+    Routes:
+    - api_keys.* → UserConfig (~/.gitctx/config.yml)
+    - search.*, index.*, model.* → RepoConfig (.gitctx/config.yml)
+    """
+
+    def __init__(self) -> None:
+        """Initialize user and repo configs."""
+        self.user = UserConfig()
+        self.repo = RepoConfig()
+
+    def get(self, key: str) -> Any:
+        """Get config value, routing by key pattern."""
+        if key.startswith("api_keys."):
+            return self._get_from_user(key)
+        else:
+            return self._get_from_repo(key)
+
+    def _get_from_user(self, key: str) -> Any:
+        """Get value from user config by navigating nested attributes.
+
+        Recursively traverses the user config object using dot-separated path segments.
+        Automatically unwraps Pydantic SecretStr values to return plain strings for
+        user-facing display while maintaining security benefits.
+
+        Args:
+            key: Dot-separated path to config value (e.g., "api_keys.openai").
+                 Each segment represents an attribute to access.
+
+        Returns:
+            The config value at the specified path, or None if the path doesn't exist.
+            SecretStr values are automatically unwrapped via get_secret_value().
+
+        Examples:
+            >>> config._get_from_user("api_keys.openai")
+            "sk-abc123..."  # Unwrapped from SecretStr
+
+            >>> config._get_from_user("api_keys.nonexistent")
+            None
+        """
+        parts = key.split(".")
+        current: Any = self.user
+        for part in parts:
+            current = getattr(current, part, None)
+            if current is None:
+                return None
+
+        # Handle SecretStr
+        if hasattr(current, "get_secret_value"):
+            return current.get_secret_value()
+        return current
+
+    def _get_from_repo(self, key: str) -> Any:
+        """Get value from repo config by navigating nested attributes.
+
+        Recursively traverses the repo config object using dot-separated path segments.
+        Used for team settings like search limits, index parameters, and model configuration.
+
+        Args:
+            key: Dot-separated path to config value (e.g., "search.limit").
+                 Each segment represents an attribute to access.
+
+        Returns:
+            The config value at the specified path, or None if the path doesn't exist.
+
+        Examples:
+            >>> config._get_from_repo("search.limit")
+            10
+
+            >>> config._get_from_repo("search.nonexistent")
+            None
+        """
+        parts = key.split(".")
+        current: Any = self.repo
+        for part in parts:
+            current = getattr(current, part, None)
+            if current is None:
+                return None
+        return current
+
+    def set(self, key: str, value: Any) -> None:
+        """Set config value, routing by key pattern."""
+        if key.startswith("api_keys."):
+            self._set_in_user(key, value)
+            self.user.save()  # → ~/.gitctx/config.yml
+        else:
+            self._set_in_repo(key, value)
+            self.repo.save()  # → .gitctx/config.yml
+
+    def _set_in_user(self, key: str, value: Any) -> None:
+        """Set value in user config."""
+        parts = key.split(".")
+        current: Any = self.user
+        for part in parts[:-1]:
+            current = getattr(current, part)
+        setattr(current, parts[-1], value)
+
+    def _set_in_repo(self, key: str, value: Any) -> None:
+        """Set value in repo config with Pydantic validation."""
+        parts = key.split(".")
+        if len(parts) != 2:
+            raise AttributeError(f"Invalid repo config key: {key}")
+
+        section, field = parts
+        # Get current section model
+        section_model = getattr(self.repo, section)
+        # Build updated dict with type coercion
+        updated_dict = section_model.model_dump()
+        updated_dict[field] = value
+        # Rebuild model to trigger validation and type coercion
+        new_section = type(section_model)(**updated_dict)
+        setattr(self.repo, section, new_section)
+
+    def _get_api_key_source(self, key: str) -> str:
+        """Determine source for API key configuration.
+
+        Args:
+            key: API key config path (e.g., "api_keys.openai")
+
+        Returns:
+            Source indicator string (e.g., "(from OPENAI_API_KEY)")
+        """
+        # Check OPENAI_API_KEY env var
+        if key == "api_keys.openai" and os.getenv("OPENAI_API_KEY"):
+            return "(from OPENAI_API_KEY)"
+
+        # Check user config file
+        user_home = Path(os.environ.get("HOME", str(Path.home())))
+        user_config_path = user_home / ".gitctx" / "config.yml"
+        if user_config_path.exists():
+            try:
+                with user_config_path.open() as f:
+                    config_data = yaml.safe_load(f) or {}
+                if "api_keys" in config_data:
+                    return "(from user config)"
+            except Exception:
+                pass
+
+        return "(default)"
+
+    def _get_repo_setting_source(self, key: str) -> str:
+        """Determine source for repo setting configuration.
+
+        Args:
+            key: Repo setting config path (e.g., "search.limit")
+
+        Returns:
+            Source indicator string (e.g., "(from GITCTX_SEARCH__LIMIT)")
+        """
+        # Check GITCTX_* env vars
+        env_key = f"GITCTX_{key.upper().replace('.', '__')}"
+        if os.getenv(env_key):
+            return f"(from {env_key})"
+
+        # Check repo config file
+        repo_config_path = Path(".gitctx/config.yml")
+        if repo_config_path.exists():
+            try:
+                with repo_config_path.open() as f:
+                    config_data = yaml.safe_load(f) or {}
+                # Navigate nested dict
+                parts = key.split(".")
+                current = config_data
+                for part in parts:
+                    if isinstance(current, dict) and part in current:
+                        current = current[part]
+                    else:
+                        return "(default)"
+                return "(from repo config)"
+            except Exception:
+                pass
+
+        return "(default)"
+
+    def get_source(self, key: str) -> str:
+        """Get the source of a configuration value."""
+        if key.startswith("api_keys."):
+            return self._get_api_key_source(key)
+        else:
+            return self._get_repo_setting_source(key)
+
+
+def init_repo_config() -> None:
+    """Initialize .gitctx/ structure."""
+    gitctx_dir = Path(".gitctx")
+    gitctx_dir.mkdir(exist_ok=True)
+
+    # Create config.yml
+    config_file = gitctx_dir / "config.yml"
+    if not config_file.exists():
+        RepoConfig().save()
+
+    # Create .gitignore
+    gitignore_content = """# LanceDB vector database - never commit
+db/
+
+# Application logs - never commit
+logs/
+*.log
+"""
+    (gitctx_dir / ".gitignore").write_text(gitignore_content)

--- a/src/gitctx/core/repo_config.py
+++ b/src/gitctx/core/repo_config.py
@@ -1,0 +1,103 @@
+"""Repo-level configuration (team settings only)."""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict, YamlConfigSettingsSource
+
+
+class SearchSettings(BaseModel):
+    """Search configuration."""
+
+    limit: int = Field(default=10, gt=0, le=100)
+    rerank: bool = True
+
+
+class IndexSettings(BaseModel):
+    """Indexing configuration."""
+
+    chunk_size: int = Field(default=1000, gt=0)
+    chunk_overlap: int = Field(default=200, ge=0)
+
+
+class ModelSettings(BaseModel):
+    """Model configuration."""
+
+    embedding: str = "text-embedding-3-large"
+
+
+class RepoConfig(BaseSettings):
+    """Repo config (.gitctx/config.yml) - team settings only.
+
+    Precedence:
+    1. GITCTX_* env vars (highest)
+    2. Repo YAML file
+    3. Defaults
+
+    Default YAML content (created by config init):
+    ```yaml
+    search:
+      limit: 10
+      rerank: true
+    index:
+      chunk_size: 1000
+      chunk_overlap: 200
+    model:
+      embedding: text-embedding-3-large
+    ```
+    """
+
+    search: SearchSettings = Field(default_factory=SearchSettings)
+    index: IndexSettings = Field(default_factory=IndexSettings)
+    model: ModelSettings = Field(default_factory=ModelSettings)
+
+    model_config = SettingsConfigDict(
+        env_prefix="GITCTX_",
+        env_nested_delimiter="__",
+        case_sensitive=False,
+    )
+
+    @classmethod
+    def settings_customise_sources(  # type: ignore[override]
+        cls,
+        settings_cls: type["RepoConfig"],
+        init_settings: Any,
+        env_settings: Any,
+        dotenv_settings: Any,  # noqa: ARG003
+        file_secret_settings: Any,  # noqa: ARG003
+    ) -> tuple[Any, ...]:
+        """Customize settings sources to support dynamic YAML file path."""
+
+        # Create YAML source with dynamic path
+        yaml_file = Path(".gitctx/config.yml")
+        if yaml_file.exists():
+            yaml_source = YamlConfigSettingsSource(settings_cls, yaml_file=yaml_file)
+        else:
+
+            def empty_source() -> dict[str, Any]:
+                return {}
+
+            yaml_source = empty_source  # type: ignore[assignment]
+
+        return (
+            init_settings,
+            env_settings,  # GITCTX_* env vars
+            yaml_source,
+        )
+
+    def save(self) -> None:
+        """Save team settings to repo config file."""
+        config_path = Path(".gitctx/config.yml")
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = {
+            "search": self.search.model_dump(),
+            "index": self.index.model_dump(),
+            "model": self.model.model_dump(),
+        }
+
+        with config_path.open("w") as f:
+            yaml.dump(data, f, default_flow_style=False)
+        config_path.chmod(0o644)  # Safe to commit

--- a/src/gitctx/core/user_config.py
+++ b/src/gitctx/core/user_config.py
@@ -1,0 +1,166 @@
+"""User-level configuration (API keys only)."""
+
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, SecretStr
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    YamlConfigSettingsSource,
+)
+
+
+class MaskedSecretStr(SecretStr):
+    """SecretStr that displays first 3 and last 3 characters when printed.
+
+    Inherits all security benefits of SecretStr (prevents logging, repr protection)
+    but provides custom masking format for user-facing display.
+
+    Example:
+        >>> secret = MaskedSecretStr("sk-abc123")
+        >>> str(secret)
+        'sk-...123'
+    """
+
+    def __repr__(self) -> str:
+        """Return masked representation for debugging."""
+        return f"MaskedSecretStr('{self._mask()}')"
+
+    def __str__(self) -> str:
+        """Return masked string for display."""
+        return self._mask()
+
+    def _mask(self) -> str:
+        """Mask the secret value showing first/last 3 chars.
+
+        Returns:
+            Masked string in format 'abc...xyz' if length > 6, else '***'
+        """
+        value = self.get_secret_value()
+        if len(value) > 6:
+            return f"{value[:3]}...{value[-3:]}"
+        return "***"
+
+
+def _get_user_home() -> Path:
+    """Get user home directory, respecting HOME env var.
+
+    On Unix, Path.home() respects HOME environment variable.
+    On Windows, Path.home() ignores HOME and uses USERPROFILE.
+    This helper ensures HOME is used when set (critical for testing).
+
+    Returns:
+        Path: User home directory
+    """
+    return Path(os.environ.get("HOME", str(Path.home())))
+
+
+class ApiKeys(BaseModel):
+    """API key configuration."""
+
+    openai: MaskedSecretStr | None = Field(default=None, description="OpenAI API key")
+
+
+class ProviderEnvSource(PydanticBaseSettingsSource):
+    """Custom source for OPENAI_API_KEY env var."""
+
+    def get_field_value(self, field: Any, field_name: str) -> tuple[Any, str, bool]:
+        """This method is required by Pydantic's settings source interface, but is not used in this custom source.
+
+        Only the __call__ method is invoked by Pydantic when loading settings from this source.
+        See: https://docs.pydantic.dev/latest/concepts/settings/#customise-sources
+        """
+        raise NotImplementedError()
+
+    def __call__(self) -> dict[str, Any]:
+        """Load OPENAI_API_KEY from environment."""
+        d: dict[str, Any] = {}
+        if openai_key := os.getenv("OPENAI_API_KEY"):
+            d["api_keys"] = {"openai": openai_key}
+        return d
+
+
+class UserConfig(BaseSettings):
+    """User config (~/.gitctx/config.yml) - API keys only.
+
+    Precedence:
+    1. OPENAI_API_KEY env var (highest)
+    2. User YAML file
+    3. Defaults
+    """
+
+    api_keys: ApiKeys = Field(default_factory=ApiKeys)
+
+    model_config = SettingsConfigDict(
+        case_sensitive=False,
+        validate_default=True,
+    )
+
+    @classmethod
+    def settings_customise_sources(  # type: ignore[override]
+        cls,
+        settings_cls: type["UserConfig"],
+        init_settings: Any,
+        env_settings: Any,  # noqa: ARG003
+        dotenv_settings: Any,  # noqa: ARG003
+        file_secret_settings: Any,  # noqa: ARG003
+    ) -> tuple[Any, ...]:
+        """Customize settings sources to support OPENAI_API_KEY precedence."""
+        # Create YAML source with dynamic path
+        yaml_file = _get_user_home() / ".gitctx" / "config.yml"
+        if yaml_file.exists():
+            # Check file permissions for security
+            stat = yaml_file.stat()
+            # Check if group or others have any permissions (should be 0600)
+            if stat.st_mode & 0o077:  # Group (o70) or others (o07) have access
+                import sys
+
+                # Use stderr to avoid interfering with command output
+                current_perms = oct(stat.st_mode)[-3:]
+                # Use simple text for cross-platform compatibility (no Unicode symbols)
+                warning = (
+                    f"Warning: User config has insecure permissions "
+                    f"(current: {current_perms}, should be 0600)\n"
+                )
+                sys.stderr.write(warning)
+
+            yaml_source = YamlConfigSettingsSource(settings_cls, yaml_file=yaml_file)
+        else:
+
+            def empty_source() -> dict[str, Any]:
+                return {}
+
+            yaml_source = empty_source  # type: ignore[assignment]
+
+        return (
+            init_settings,
+            ProviderEnvSource(settings_cls),  # OPENAI_API_KEY
+            yaml_source,
+        )
+
+    def save(self) -> None:
+        """Save API keys to user config file."""
+        config_path = _get_user_home() / ".gitctx" / "config.yml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = {}
+        if self.api_keys.openai is not None:
+            # Handle both SecretStr and plain string (str accepted via validation)
+            if isinstance(self.api_keys.openai, SecretStr):
+                openai_value = self.api_keys.openai.get_secret_value()
+            else:
+                openai_value = str(self.api_keys.openai)
+            data["api_keys"] = {"openai": openai_value}
+
+        # Secure permissions
+        old_umask = os.umask(0o077)
+        try:
+            with config_path.open("w") as f:
+                yaml.dump(data, f, default_flow_style=False)
+        finally:
+            os.umask(old_umask)
+        config_path.chmod(0o600)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,14 +11,6 @@ Author: gitctx team
 """
 
 import os
-
-# CRITICAL: Set environment variables BEFORE any CLI module imports
-# This ensures Rich Console objects are created without ANSI escape codes
-# Console checks these at __init__ time, so they must be set before import
-os.environ["TTY_COMPATIBLE"] = "0"  # Rich 2025 standard - disables ANSI codes
-os.environ["NO_COLOR"] = "1"  # Standard fallback for no color
-os.environ["TERM"] = "dumb"  # Simple terminal type
-
 import sys
 from pathlib import Path
 
@@ -27,14 +19,58 @@ import pytest
 # Add src to path for testing
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
+# CRITICAL: Disable ANSI colors BEFORE any CLI module imports
+# Rich Console checks these environment variables at __init__ time,
+# so they must be set before any imports. We set them at module level
+# to ensure they're available before pytest starts running tests.
+# These are test-only settings and won't affect production code.
+os.environ["TTY_COMPATIBLE"] = "0"  # Rich 2025 standard - disables ANSI codes
+os.environ["NO_COLOR"] = "1"  # Standard fallback for no color
+os.environ["TERM"] = "dumb"  # Simple terminal type
+
 # Import step definitions to register them with pytest-bdd
 pytest_plugins = ["tests.e2e.steps.cli_steps"]
+
+
+# === UTILITY FUNCTIONS ===
+
+
+def is_windows() -> bool:
+    """Check if running on Windows platform.
+
+    Centralized platform detection to avoid duplication across test files.
+
+    Returns:
+        bool: True if running on Windows, False otherwise
+    """
+    import platform
+
+    return platform.system() == "Windows"
+
+
+def get_platform_ssh_command() -> str:
+    """Get platform-specific SSH blocking command.
+
+    Returns:
+        str: "exit 1" on Windows, "/bin/false" on Unix
+    """
+    return "exit 1" if is_windows() else "/bin/false"
+
+
+def get_platform_null_device() -> str:
+    """Get platform-specific null device path.
+
+    Returns:
+        str: "NUL" on Windows, "/dev/null" on Unix
+    """
+    return "NUL" if is_windows() else "/dev/null"
+
 
 # === PHASE 1: Core Security Fixtures (Current) ===
 
 
 @pytest.fixture
-def git_isolation_base() -> dict[str, str]:
+def git_isolation_base(tmp_path: Path) -> dict[str, str]:
     """
     Base git isolation configuration.
 
@@ -49,20 +85,43 @@ def git_isolation_base() -> dict[str, str]:
     NOTE: Unix-specific paths (/dev/null, /bin/false) are intentional for
     security isolation. Git on Windows typically runs under Unix-like environments
     (WSL, Git Bash, MSYS2). Our CI tests verify this works across all platforms.
+
+    Related fixtures:
+    - e2e_git_isolation_env: Extends this with full environment (tests/e2e/conftest.py)
+    - e2e_git_repo: Uses this for git operations (tests/e2e/conftest.py)
+    - e2e_git_repo_factory: Uses this for creating custom repos (tests/e2e/conftest.py)
+
+    See also: tests/e2e/CLAUDE.md for E2E testing security guidelines
     """
+    # For Windows, use a command that fails immediately (exit 1 works cross-platform in Git Bash/MSYS2)
+    # For Unix, use /bin/false for explicit blocking
+    ssh_block_cmd = "exit 1" if is_windows() else "/bin/false"
+
+    # For Windows, use NUL device; for Unix, use /dev/null
+    # This prevents git config from hanging when trying to access these paths
+    null_device = "NUL" if is_windows() else "/dev/null"
+
+    # Create an empty GPG home directory to test isolation
+    # SECURITY: Using a temp directory instead of NUL/dev/null because:
+    # - NUL causes GPG to hang on Windows (timeout masks security violations)
+    # - Empty directory allows GPG to run but find no keys (proper test)
+    # - If keys ARE found, we have a real security problem
+    gpg_home = tmp_path / "gnupg_isolated"
+    gpg_home.mkdir(mode=0o700, exist_ok=True)
+
     return {
         # Disable git configuration access
-        "GIT_CONFIG_GLOBAL": "/dev/null",
-        "GIT_CONFIG_SYSTEM": "/dev/null",
+        "GIT_CONFIG_GLOBAL": null_device,
+        "GIT_CONFIG_SYSTEM": null_device,
         "GIT_TERMINAL_PROMPT": "0",
-        "GIT_ASKPASS": "/bin/false",
+        "GIT_ASKPASS": ssh_block_cmd,
         # Completely disable SSH
-        "GIT_SSH_COMMAND": "/bin/false",
+        "GIT_SSH_COMMAND": ssh_block_cmd,
         "SSH_AUTH_SOCK": "",
-        "SSH_ASKPASS": "/bin/false",
-        # Disable GPG signing
+        "SSH_ASKPASS": ssh_block_cmd,
+        # Disable GPG signing - use empty temp directory
         "GPG_TTY": "",
-        "GNUPGHOME": "/dev/null",
+        "GNUPGHOME": str(gpg_home),
     }
 
 
@@ -71,8 +130,26 @@ def temp_home(tmp_path: Path) -> Path:
     """
     Create isolated HOME directory for tests.
 
+    Creates a temporary home directory with .gitctx subdirectory already
+    initialized. Use this when you need direct access to a home directory.
+
     Returns:
         Path: Temporary home directory with .gitctx subdir
+
+    Related fixtures:
+    - isolated_env: Combines temp_home + env var setup (tests/unit/conftest.py)
+    - isolated_cli_runner: Uses temp_home for CLI tests (tests/conftest.py)
+    - e2e_git_isolation_env: Uses temp_home in environment (tests/e2e/conftest.py)
+
+    Usage:
+        def test_config_file(temp_home, monkeypatch):
+            monkeypatch.setenv("HOME", str(temp_home))
+            config_path = temp_home / ".gitctx" / "config.yml"
+            # .gitctx already exists, just write the file
+            config_path.write_text("...")
+
+    See also:
+    - For most tests, use isolated_env instead (cleaner API)
     """
     home = tmp_path / "test_home"
     home.mkdir()
@@ -81,21 +158,79 @@ def temp_home(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def cli_runner():
+def unit_cli_runner():
     """
-    CLI test runner for unit tests.
+    CLI test runner for pure unit tests (NO filesystem isolation).
 
     Returns CliRunner for testing Typer CLI commands in-process.
 
+    WARNING: This fixture does NOT isolate the filesystem or environment.
+    Only use this for tests that:
+    - Test --help output
+    - Test error messages
+    - Do NOT create files or directories
+    - Do NOT invoke git operations
+
+    For most tests, use `cli_runner` (alias for isolated_cli_runner) instead.
+    For E2E tests with subprocess isolation, use e2e_cli_runner instead.
+
     Note: Console colors are disabled globally via TTY_COMPATIBLE=0 set at
-    module level (top of this file). This must be done before CLI modules
-    are imported, as Console checks environment at __init__ time.
+    module level (top of this file).
+    """
+    from typer.testing import CliRunner
+
+    return CliRunner()
+
+
+@pytest.fixture
+def isolated_cli_runner(tmp_path: Path, monkeypatch):
+    """
+    CLI test runner with complete filesystem and environment isolation.
+
+    Returns CliRunner that runs in a temporary directory with isolated HOME.
+
+    CRITICAL: This is the SAFE DEFAULT for CLI testing. Use this fixture for
+    any test that:
+    - Creates files or directories (like .gitctx)
+    - Invokes git operations
+    - Reads/writes config files
+    - When in doubt, use this!
+
+    Isolation provided:
+    - Working directory: tmp_path
+    - HOME directory: tmp_path/home
+    - Environment: OPENAI_API_KEY cleared
 
     For E2E tests with subprocess isolation, use e2e_cli_runner instead.
     """
     from typer.testing import CliRunner
 
+    # Create isolated home directory
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    # Isolate both working directory and HOME
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    # Clear OPENAI_API_KEY to prevent env var interference
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
     return CliRunner()
+
+
+@pytest.fixture
+def cli_runner(isolated_cli_runner):
+    """
+    Default CLI test runner (SAFE by default).
+
+    This is an alias for isolated_cli_runner, making the safe choice the default.
+    Use this fixture for most CLI tests.
+
+    For pure unit tests that don't touch the filesystem, you can explicitly
+    use unit_cli_runner instead.
+    """
+    return isolated_cli_runner
 
 
 # === PHASE 2: Repository Fixtures (TODO - Next Sprint) ===

--- a/tests/e2e/features/cli.feature
+++ b/tests/e2e/features/cli.feature
@@ -24,11 +24,11 @@ Feature: CLI Foundation
   Scenario: Config set command
     When I run "gitctx config set api_keys.openai sk-test123"
     Then the exit code should be 0
-    And the output should contain "Set"
+    And the output should contain "set"
 
   Scenario: Config get command
     When I run "gitctx config get nonexistent.key"
-    Then the exit code should be 0
+    Then the exit code should not be 0
     And the output should contain "not set"
 
   Scenario: Config list command
@@ -86,3 +86,176 @@ Feature: CLI Foundation
     Then the exit code should be 0
     And the output should contain "Quick start"
     And the output should contain "gitctx index"
+
+  # TASK-0001.1.2.1: Real Configuration Management with User/Repo Separation
+
+  Scenario: config init creates repo structure (default terse output)
+    When I run "gitctx config init"
+    Then the exit code should be 0
+    And the output should contain "Initialized .gitctx/"
+    And the output should not contain "Created"
+    And the output should not contain "Next steps"
+    And the file ".gitctx/config.yml" should exist
+    And the file ".gitctx/.gitignore" should exist
+    And ".gitctx/.gitignore" should contain "# LanceDB vector database - never commit"
+    And ".gitctx/.gitignore" should contain "db/"
+    And ".gitctx/.gitignore" should contain "# Application logs - never commit"
+    And ".gitctx/.gitignore" should contain "logs/"
+    And ".gitctx/.gitignore" should contain "*.log"
+
+  Scenario: config init quiet mode suppresses all output
+    When I run "gitctx config init --quiet"
+    Then the exit code should be 0
+    And the output should be empty
+
+  Scenario: config init verbose mode shows detailed output
+    When I run "gitctx config init --verbose"
+    Then the exit code should be 0
+    And the output should contain "Initialized .gitctx/"
+    And the output should contain "Created .gitctx/config.yml"
+    And the output should contain "Created .gitctx/.gitignore"
+    And the output should contain "Next steps:"
+    And the output should contain "1. Set your API key: gitctx config set api_keys.openai sk-..."
+    And the output should contain "2. Index your repo: gitctx index"
+    And the output should contain "3. Commit to share: git add .gitctx/"
+
+  Scenario: API keys stored in user config only
+    When I run "gitctx config set api_keys.openai sk-test123"
+    Then the exit code should be 0
+    And the output should contain "set api_keys.openai"
+    And the user config file should exist at "~/.gitctx/config.yml"
+    And the file "~/.gitctx/config.yml" should contain "api_keys:"
+    And the file "~/.gitctx/config.yml" should contain "openai:"
+    And the file "~/.gitctx/config.yml" should contain "sk-test123"
+    And the file ".gitctx/config.yml" should not contain "api_keys"
+    And the file ".gitctx/config.yml" should not contain "sk-test123"
+
+  Scenario: Repo settings stored in repo config only
+    Given I run "gitctx config init"
+    When I run "gitctx config set search.limit 20"
+    Then the exit code should be 0
+    And the output should contain "set search.limit"
+    And the file ".gitctx/config.yml" should contain "search:"
+    And the file ".gitctx/config.yml" should contain "limit: 20"
+    And the file "~/.gitctx/config.yml" should not contain "search"
+    And the file "~/.gitctx/config.yml" should not contain "limit"
+
+  Scenario: config get default mode shows value only (terse)
+    Given user config contains "api_keys:\n  openai: sk-test123"
+    When I run "gitctx config get api_keys.openai"
+    Then the exit code should be 0
+    And the output should contain "sk-...123"
+    And the output should not contain "api_keys.openai ="
+    And the output should not contain "(from"
+
+  Scenario: config get verbose mode shows key and source
+    Given user config contains "api_keys:\n  openai: sk-test123"
+    When I run "gitctx config get api_keys.openai --verbose"
+    Then the exit code should be 0
+    And the output should contain "api_keys.openai"
+    And the output should contain "sk-...123"
+    And the output should contain "(from user config)"
+
+  Scenario: config get quiet mode outputs value only with no formatting
+    Given user config contains "api_keys:\n  openai: sk-test123"
+    When I run "gitctx config get api_keys.openai --quiet"
+    Then the exit code should be 0
+    And the output should contain "sk-...123"
+
+  Scenario: OPENAI_API_KEY env var overrides user config
+    Given user config contains "api_keys:\n  openai: sk-file123"
+    And environment variable "OPENAI_API_KEY" is "sk-env456"
+    When I run "gitctx config get api_keys.openai --verbose"
+    Then the output should contain "sk-...456"
+    And the output should contain "(from OPENAI_API_KEY)"
+
+  Scenario: GITCTX env var overrides repo config
+    Given repo config contains "search:\n  limit: 10"
+    And environment variable "GITCTX_SEARCH__LIMIT" is "30"
+    When I run "gitctx config get search.limit --verbose"
+    Then the output should contain "30"
+    And the output should contain "(from GITCTX_SEARCH__LIMIT)"
+
+  Scenario: config list default mode hides sources for defaults (terse)
+    Given user config contains "api_keys:\n  openai: sk-test123"
+    And repo config contains "search:\n  limit: 20"
+    When I run "gitctx config list"
+    Then the output should contain "api_keys.openai=sk-...123"
+    And the output should contain "(from user config)"
+    And the output should contain "search.limit=20"
+    And the output should contain "(from repo config)"
+    And the output should contain "model.embedding=text-embedding-3-large"
+    And the output should not contain "(default)"
+
+  Scenario: config list verbose mode shows all sources
+    Given user config contains "api_keys:\n  openai: sk-test123"
+    When I run "gitctx config list --verbose"
+    Then the output should contain "api_keys.openai=sk-...123"
+    And the output should contain "(from user config)"
+    And the output should contain "model.embedding=text-embedding-3-large"
+    And the output should contain "(default)"
+
+  Scenario: config set default mode shows terse confirmation
+    Given I run "gitctx config init"
+    When I run "gitctx config set search.limit 20"
+    Then the exit code should be 0
+    And the output should contain "set search.limit"
+    And the file ".gitctx/config.yml" should contain "search:"
+    And the file ".gitctx/config.yml" should contain "limit: 20"
+    And the file "~/.gitctx/config.yml" should not contain "search"
+
+  Scenario: config set quiet mode suppresses output
+    Given I run "gitctx config init"
+    When I run "gitctx config set search.limit 20 --quiet"
+    Then the exit code should be 0
+    And the output should be empty
+    And the file ".gitctx/config.yml" should contain "search:"
+    And the file ".gitctx/config.yml" should contain "limit: 20"
+
+  Scenario: config set api key persists to user config
+    When I run "gitctx config set api_keys.openai sk-test456"
+    Then the exit code should be 0
+    And the file "~/.gitctx/config.yml" should exist
+    And the file "~/.gitctx/config.yml" should contain "api_keys:"
+    And the file "~/.gitctx/config.yml" should contain "openai:"
+    And the file "~/.gitctx/config.yml" should contain "sk-test456"
+    And the file ".gitctx/config.yml" should not contain "sk-test456"
+    And the file ".gitctx/config.yml" should not contain "api_keys"
+
+  Scenario: Config validation catches invalid values
+    Given I run "gitctx config init"
+    When I run "gitctx config set search.limit invalid"
+    Then the exit code should be 2
+    And the error should contain "expected a number"
+    And the error should not contain "ValidationError"
+    And the error should not contain "Traceback"
+
+  Scenario: Repo config is safe to commit (no secrets)
+    Given I run "gitctx config init"
+    When I run "gitctx config set search.limit 20"
+    And I run "gitctx config set api_keys.openai sk-secret123"
+    Then the file ".gitctx/config.yml" should contain "search:"
+    And the file ".gitctx/config.yml" should contain "limit: 20"
+    And the file ".gitctx/config.yml" should not contain "sk-"
+    And the file ".gitctx/config.yml" should not contain "api_keys"
+    And the file "~/.gitctx/config.yml" should contain "api_keys:"
+    And the file "~/.gitctx/config.yml" should contain "sk-secret123"
+
+  Scenario: Malformed YAML file shows clear error
+    Given repo config contains invalid YAML "search:\n  limit: [unclosed"
+    When I run "gitctx config get search.limit"
+    Then the exit code should be 1
+    And the error should contain "Failed to parse config file"
+
+  Scenario: User config with insecure permissions shows warning
+    Given user config exists with permissions 0644
+    When I run "gitctx config get api_keys.openai"
+    Then the error should contain "insecure permissions"
+    And the error should contain "644"
+    And the error should contain "600"
+
+  Scenario: Permission denied on config save shows clear error
+    Given repo config file exists with read-only permissions
+    When I run "gitctx config set search.limit 30"
+    Then the exit code should be 6
+    And the error should contain "Permission denied"

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -3,82 +3,82 @@
 from gitctx.cli.main import app
 
 
-def test_config_command_exists(cli_runner):
+def test_config_command_exists(isolated_cli_runner):
     """Verify config command group is registered."""
-    result = cli_runner.invoke(app, ["config", "--help"])
+    result = isolated_cli_runner.invoke(app, ["config", "--help"])
     assert result.exit_code == 0
     assert "Manage" in result.stdout or "configuration" in result.stdout.lower()
 
 
-def test_config_set_command(cli_runner):
+def test_config_set_command(isolated_cli_runner):
     """Verify config set subcommand works."""
-    result = cli_runner.invoke(app, ["config", "set", "api_keys.openai", "sk-test123"])
+    result = isolated_cli_runner.invoke(app, ["config", "set", "api_keys.openai", "sk-test123"])
     assert result.exit_code == 0
     assert "set" in result.stdout.lower() or "saved" in result.stdout.lower()
 
 
-def test_config_get_command(cli_runner):
+def test_config_get_command(isolated_cli_runner):
     """Verify config get subcommand works and masks API keys."""
     # First set a value
-    cli_runner.invoke(app, ["config", "set", "api_keys.openai", "sk-test123"])
+    isolated_cli_runner.invoke(app, ["config", "set", "api_keys.openai", "sk-test123"])
     # Then get it
-    result = cli_runner.invoke(app, ["config", "get", "api_keys.openai"])
+    result = isolated_cli_runner.invoke(app, ["config", "get", "api_keys.openai"])
     assert result.exit_code == 0
     # Should mask API key in output (show first 3 and last 3)
     assert "sk-...123" in result.stdout
 
 
-def test_config_list_command(cli_runner):
+def test_config_list_command(isolated_cli_runner):
     """Verify config list subcommand works."""
     # Set a value first so list has something to show
-    cli_runner.invoke(app, ["config", "set", "test.key", "value"])
-    result = cli_runner.invoke(app, ["config", "list"])
+    isolated_cli_runner.invoke(app, ["config", "set", "test.key", "value"])
+    result = isolated_cli_runner.invoke(app, ["config", "list"])
     assert result.exit_code == 0
     # Should show key=value format
     assert "=" in result.stdout or ":" in result.stdout
 
 
-def test_config_set_requires_value(cli_runner):
+def test_config_set_requires_value(isolated_cli_runner):
     """Verify set command requires both key and value."""
-    result = cli_runner.invoke(app, ["config", "set", "test.key"])
+    result = isolated_cli_runner.invoke(app, ["config", "set", "test.key"])
     assert result.exit_code != 0
     # Typer will show error about missing VALUE argument
 
 
-def test_config_get_requires_key(cli_runner):
+def test_config_get_requires_key(isolated_cli_runner):
     """Verify get command requires key."""
-    result = cli_runner.invoke(app, ["config", "get"])
+    result = isolated_cli_runner.invoke(app, ["config", "get"])
     assert result.exit_code != 0
     # Typer will show error about missing KEY argument
 
 
-def test_config_env_override(cli_runner, monkeypatch):
+def test_config_env_override(isolated_cli_runner, monkeypatch):
     """Verify environment variables override config."""
     # Set config value
-    cli_runner.invoke(app, ["config", "set", "api_keys.openai", "sk-config123"])
+    isolated_cli_runner.invoke(app, ["config", "set", "api_keys.openai", "sk-config123"])
     # Set environment variable (should take precedence)
     monkeypatch.setenv("OPENAI_API_KEY", "sk-env123")
-    result = cli_runner.invoke(app, ["config", "get", "api_keys.openai"])
+    result = isolated_cli_runner.invoke(app, ["config", "get", "api_keys.openai", "--verbose"])
     assert result.exit_code == 0
     # Should show env value (masked)
     assert "sk-...123" in result.stdout
     # Should indicate it's from environment
-    assert "env" in result.stdout.lower() or "environment" in result.stdout.lower()
+    assert "OPENAI_API_KEY" in result.stdout
 
 
-def test_config_dot_notation(cli_runner):
+def test_config_dot_notation(isolated_cli_runner):
     """Verify dot notation works for nested keys."""
-    result = cli_runner.invoke(app, ["config", "set", "search.limit", "20"])
+    result = isolated_cli_runner.invoke(app, ["config", "set", "search.limit", "20"])
     assert result.exit_code == 0
-    result = cli_runner.invoke(app, ["config", "get", "search.limit"])
+    result = isolated_cli_runner.invoke(app, ["config", "get", "search.limit"])
     assert result.exit_code == 0
     assert "20" in result.stdout
 
 
-def test_config_list_masks_sensitive(cli_runner):
+def test_config_list_masks_sensitive(isolated_cli_runner):
     """Verify list command masks sensitive values."""
-    cli_runner.invoke(app, ["config", "set", "api_keys.openai", "sk-secret123"])
-    result = cli_runner.invoke(app, ["config", "list"])
+    isolated_cli_runner.invoke(app, ["config", "set", "api_keys.openai", "sk-secret123"])
+    result = isolated_cli_runner.invoke(app, ["config", "list"])
     assert result.exit_code == 0
     # Should show masked value in list
     assert "sk-...123" in result.stdout
@@ -86,8 +86,369 @@ def test_config_list_masks_sensitive(cli_runner):
     assert "sk-secret123" not in result.stdout
 
 
-def test_config_get_nonexistent_key(cli_runner):
+def test_config_get_nonexistent_key(isolated_cli_runner):
     """Verify getting a non-existent key shows helpful message."""
-    result = cli_runner.invoke(app, ["config", "get", "nonexistent.key"])
-    assert result.exit_code == 0  # Not an error, just not set
+    result = isolated_cli_runner.invoke(app, ["config", "get", "nonexistent.key"])
+    assert result.exit_code == 1  # Missing key is an error
     assert "not set" in result.stdout.lower() or "not found" in result.stdout.lower()
+
+
+# config init tests
+def test_config_init_creates_gitctx_directory(isolated_cli_runner):
+    """Verify config init creates .gitctx/ directory structure."""
+    from pathlib import Path
+
+    result = isolated_cli_runner.invoke(app, ["config", "init"])
+    assert result.exit_code == 0
+    assert "Initialized .gitctx/" in result.stdout
+
+    # Verify structure created
+    assert Path(".gitctx").is_dir()
+    assert Path(".gitctx/config.yml").is_file()
+    assert Path(".gitctx/.gitignore").is_file()
+
+    # First run should show tip
+    assert "Tip" in result.stdout or "tip" in result.stdout.lower()
+
+
+def test_config_init_verbose_mode(isolated_cli_runner):
+    """Verify config init --verbose shows detailed output."""
+    result = isolated_cli_runner.invoke(app, ["config", "init", "--verbose"])
+    assert result.exit_code == 0
+    assert "Created .gitctx/config.yml" in result.stdout
+    assert "Created .gitctx/.gitignore" in result.stdout
+    assert "Next steps" in result.stdout
+
+
+def test_config_init_quiet_mode(isolated_cli_runner):
+    """Verify config init --quiet suppresses output."""
+    result = isolated_cli_runner.invoke(app, ["config", "init", "--quiet"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == ""
+
+
+def test_config_init_already_exists(isolated_cli_runner):
+    """Verify config init handles already initialized directory."""
+
+    # First init
+    isolated_cli_runner.invoke(app, ["config", "init"])
+
+    # Second init - should handle gracefully
+    result = isolated_cli_runner.invoke(app, ["config", "init"])
+    # Should still succeed (idempotent)
+    assert result.exit_code == 0
+
+
+def test_config_init_permission_error(isolated_cli_runner, monkeypatch):
+    """Verify config init handles permission errors."""
+    from pathlib import Path
+
+    def mock_mkdir(*args, **kwargs):
+        raise PermissionError("Permission denied")
+
+    # Mock Path.mkdir to raise PermissionError
+    monkeypatch.setattr(Path, "mkdir", mock_mkdir)
+
+    result = isolated_cli_runner.invoke(app, ["config", "init"])
+    assert result.exit_code == 6  # Exit code 6 = permission error
+    assert "Permission denied" in result.stderr or "Permission denied" in result.stdout
+
+
+# config set error tests
+def test_config_set_validation_error(isolated_cli_runner):
+    """Verify config set handles validation errors with user-friendly message."""
+    isolated_cli_runner.invoke(app, ["config", "init"])
+    result = isolated_cli_runner.invoke(app, ["config", "set", "search.limit", "invalid"])
+    assert result.exit_code == 2  # Exit code 2 = validation error
+    # Should show user-friendly error message, not Pydantic technical details
+    assert (
+        "expected a number" in result.stderr.lower() or "expected a number" in result.stdout.lower()
+    )
+    # Should NOT show Pydantic internal details
+    assert "ValidationError" not in result.stderr and "ValidationError" not in result.stdout
+    assert "Traceback" not in result.stderr and "Traceback" not in result.stdout
+
+
+def test_config_set_out_of_range_validation(isolated_cli_runner):
+    """Verify config set shows friendly error for out-of-range values."""
+    isolated_cli_runner.invoke(app, ["config", "init"])
+    # search.limit has constraint: gt=0, le=100
+    result = isolated_cli_runner.invoke(app, ["config", "set", "search.limit", "500"])
+    assert result.exit_code == 2
+    # Should explain the constraint
+    assert "less than" in result.stderr.lower() or "too large" in result.stderr.lower()
+
+
+def test_config_set_unknown_key(isolated_cli_runner):
+    """Verify config set handles unknown keys."""
+    isolated_cli_runner.invoke(app, ["config", "init"])
+    result = isolated_cli_runner.invoke(app, ["config", "set", "unknown.invalid", "value"])
+    assert result.exit_code != 0
+    # Should show error about unknown key
+
+
+# config get error tests
+def test_config_get_unknown_key_error(isolated_cli_runner):
+    """Verify config get handles unknown keys gracefully."""
+    isolated_cli_runner.invoke(app, ["config", "init"])
+    result = isolated_cli_runner.invoke(app, ["config", "get", "totally.invalid.key"])
+    assert result.exit_code == 1
+    assert "not set" in result.stdout.lower() or "error" in result.stderr.lower()
+
+
+# config list edge cases
+def test_config_list_quiet_mode(isolated_cli_runner):
+    """Verify config list --quiet shows minimal output."""
+    isolated_cli_runner.invoke(app, ["config", "init"])
+    result = isolated_cli_runner.invoke(app, ["config", "list", "--quiet"])
+    assert result.exit_code == 0
+    # Quiet mode should still show values, just without decoration
+    assert "=" in result.stdout
+
+
+def test_config_list_verbose_mode_shows_sources(isolated_cli_runner):
+    """Verify config list --verbose shows config sources."""
+    isolated_cli_runner.invoke(app, ["config", "init"])
+    result = isolated_cli_runner.invoke(app, ["config", "list", "--verbose"])
+    assert result.exit_code == 0
+    # Verbose should show sources like "(from default)" or "(from config)"
+    assert "from" in result.stdout.lower() or "default" in result.stdout.lower()
+
+
+def test_config_set_permission_error_on_save(isolated_cli_runner, monkeypatch):
+    """Test config set handles permission error when saving."""
+    from pathlib import Path
+
+    isolated_cli_runner.invoke(app, ["config", "init"])
+
+    # Mock Path.open to raise PermissionError
+    original_open = Path.open
+
+    def mock_open(self, *args, **kwargs):
+        if str(self).endswith("config.yml") and "w" in str(args):
+            raise PermissionError("Permission denied")
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", mock_open)
+
+    result = isolated_cli_runner.invoke(app, ["config", "set", "search.limit", "20"])
+    assert result.exit_code == 6
+    assert "Permission denied" in result.stderr or "Permission denied" in result.stdout
+
+
+def test_config_get_corrupted_yaml(isolated_cli_runner):
+    """Test config get handles corrupted YAML file."""
+    from pathlib import Path
+
+    isolated_cli_runner.invoke(app, ["config", "init"])
+
+    # Corrupt the YAML file
+    config_file = Path(".gitctx/config.yml")
+    config_file.write_text("search:\n  limit: [unclosed")
+
+    result = isolated_cli_runner.invoke(app, ["config", "get", "search.limit"])
+    assert result.exit_code == 1
+    assert "parse" in result.stderr.lower() or "error" in result.stderr.lower()
+
+
+def test_config_set_without_init_shows_clear_error(isolated_cli_runner):
+    """Verify config set without init shows helpful message."""
+    # Don't call config init first - try to set directly
+    result = isolated_cli_runner.invoke(app, ["config", "set", "search.limit", "20"])
+    # Should succeed (creates config automatically) or fail gracefully
+    # The important thing is no crash
+    assert result.exit_code in [0, 1]
+
+
+def test_config_init_unexpected_error(isolated_cli_runner, monkeypatch):
+    """Test config init handles unexpected errors gracefully."""
+    from pathlib import Path
+
+    def mock_mkdir(*args, **kwargs):
+        raise RuntimeError("Unexpected filesystem error")
+
+    monkeypatch.setattr(Path, "mkdir", mock_mkdir)
+    result = isolated_cli_runner.invoke(app, ["config", "init"])
+    assert result.exit_code == 1
+    assert "Error:" in result.stderr or "Error:" in result.stdout
+
+
+def test_config_list_completely_empty(isolated_cli_runner):
+    """Test config list with no config set at all."""
+    # Don't initialize - fresh state with no config files
+    result = isolated_cli_runner.invoke(app, ["config", "list"])
+    assert result.exit_code == 0
+    # Should handle gracefully - either show defaults or "No configuration set"
+    assert "No configuration" in result.stdout or "=" in result.stdout
+
+
+def test_config_init_already_exists_quiet_mode(isolated_cli_runner):
+    """Test config init when already exists with quiet mode."""
+    isolated_cli_runner.invoke(app, ["config", "init"])
+    result = isolated_cli_runner.invoke(app, ["config", "init", "--quiet"])
+    assert result.exit_code == 0
+    # Should succeed silently without showing warning
+    assert result.stdout.strip() == ""
+
+
+def test_config_set_generic_error(isolated_cli_runner, monkeypatch):
+    """Test config set handles generic exceptions during save."""
+    from pathlib import Path
+
+    isolated_cli_runner.invoke(app, ["config", "init"])
+
+    # Mock to raise a generic exception during write
+    original_write_text = Path.write_text
+
+    def mock_write_text(self, *args, **kwargs):
+        if str(self).endswith("config.yml") and len(args) > 0:
+            raise OSError("Disk full or other OS error")
+        return original_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", mock_write_text)
+
+    result = isolated_cli_runner.invoke(app, ["config", "set", "search.limit", "20"])
+    # Should fail gracefully without crash
+    assert result.exit_code in [0, 1]
+
+
+def test_config_get_attribute_error_for_unknown_key(isolated_cli_runner):
+    """Test config get with unknown key triggers AttributeError handling."""
+    isolated_cli_runner.invoke(app, ["config", "init"])
+    result = isolated_cli_runner.invoke(app, ["config", "get", "completely.unknown.nested.key"])
+    assert result.exit_code != 0
+    assert "Unknown configuration key" in result.stderr or "not set" in result.stdout.lower()
+
+
+# Additional tests to improve coverage to 90%+
+
+
+def test_config_init_file_exists_error_non_quiet(isolated_cli_runner, monkeypatch):
+    """Test config init shows warning when FileExistsError occurs (non-quiet mode)."""
+    # First init normally
+    isolated_cli_runner.invoke(app, ["config", "init"])
+
+    # Mock init_repo_config to raise FileExistsError
+    def mock_init_repo_config():
+        raise FileExistsError(".gitctx/ already exists")
+
+    monkeypatch.setattr("gitctx.cli.config.init_repo_config", mock_init_repo_config)
+
+    # Run init again without --quiet
+    result = isolated_cli_runner.invoke(app, ["config", "init"])
+    assert result.exit_code == 0
+    assert "already initialized" in result.stdout.lower() or "warning" in result.stdout.lower()
+
+
+def test_config_set_quiet_mode(isolated_cli_runner):
+    """Test config set with --quiet suppresses all output."""
+    isolated_cli_runner.invoke(app, ["config", "init"])
+    result = isolated_cli_runner.invoke(app, ["config", "set", "search.limit", "25", "--quiet"])
+    assert result.exit_code == 0
+    # Quiet mode should produce no output
+    assert result.stdout.strip() == ""
+
+
+def test_config_set_verbose_mode(isolated_cli_runner):
+    """Test config set with --verbose shows config location."""
+    isolated_cli_runner.invoke(app, ["config", "init"])
+
+    # Test verbose for repo config
+    result = isolated_cli_runner.invoke(app, ["config", "set", "search.limit", "25", "--verbose"])
+    assert result.exit_code == 0
+    assert "repo config" in result.stdout.lower() or ".gitctx/config.yml" in result.stdout
+
+    # Test verbose for user config (API keys)
+    result = isolated_cli_runner.invoke(
+        app, ["config", "set", "api_keys.openai", "sk-test456", "--verbose"]
+    )
+    assert result.exit_code == 0
+    assert "user config" in result.stdout.lower() or "~/.gitctx/config.yml" in result.stdout
+
+
+def test_config_set_file_not_found_error(isolated_cli_runner, monkeypatch):
+    """Test config set shows helpful error when .gitctx doesn't exist."""
+    from gitctx.core.config import GitCtxSettings
+
+    # Don't run init - try to set config without .gitctx existing
+    # Mock settings.set to raise FileNotFoundError
+    original_set = GitCtxSettings.set
+
+    def mock_set(self, key, value):
+        if not key.startswith("api_keys."):
+            raise FileNotFoundError(".gitctx/config.yml not found")
+        return original_set(self, key, value)
+
+    monkeypatch.setattr(GitCtxSettings, "set", mock_set)
+
+    result = isolated_cli_runner.invoke(app, ["config", "set", "search.limit", "20"])
+    assert result.exit_code == 1
+    assert "gitctx config init" in result.stderr.lower() or "run" in result.stderr.lower()
+
+
+def test_config_set_attribute_error(isolated_cli_runner):
+    """Test config set with truly invalid key shows proper error."""
+    isolated_cli_runner.invoke(app, ["config", "init"])
+    result = isolated_cli_runner.invoke(app, ["config", "set", "completely.invalid.key", "value"])
+    assert result.exit_code == 2
+    assert "unknown" in result.stderr.lower() or "error" in result.stderr.lower()
+
+
+def test_config_get_api_key_not_set(isolated_cli_runner, monkeypatch):
+    """Test config get when API key field returns None."""
+    isolated_cli_runner.invoke(app, ["config", "init"])
+
+    # Try to get API key that was never set
+    result = isolated_cli_runner.invoke(app, ["config", "get", "api_keys.openai"])
+    assert result.exit_code == 1
+    assert "not set" in result.stdout.lower()
+
+
+def test_config_get_quiet_mode_with_value(isolated_cli_runner):
+    """Test config get --quiet outputs only the value."""
+    isolated_cli_runner.invoke(app, ["config", "init"])
+    isolated_cli_runner.invoke(app, ["config", "set", "search.limit", "30"])
+
+    result = isolated_cli_runner.invoke(app, ["config", "get", "search.limit", "--quiet"])
+    assert result.exit_code == 0
+    # Should output just the value, nothing else
+    assert result.stdout.strip() == "30"
+
+
+def test_config_get_attribute_error_on_navigation(isolated_cli_runner, monkeypatch):
+    """Test config get AttributeError path when getattr fails during navigation."""
+    from gitctx.core.config import GitCtxSettings
+
+    isolated_cli_runner.invoke(app, ["config", "init"])
+
+    # Mock get to raise AttributeError
+    def mock_get(self, key):
+        raise AttributeError(f"No such attribute: {key}")
+
+    monkeypatch.setattr(GitCtxSettings, "get", mock_get)
+
+    result = isolated_cli_runner.invoke(app, ["config", "get", "search.limit"])
+    assert result.exit_code == 2
+    assert "unknown" in result.stderr.lower() or "error" in result.stderr.lower()
+
+
+def test_config_list_truly_empty(isolated_cli_runner, monkeypatch):
+    """Test config list when no API keys or config values are set."""
+    from gitctx.core.config import GitCtxSettings
+
+    # Mock settings to have completely empty config
+    original_init = GitCtxSettings.__init__
+
+    def mock_init(self):
+        original_init(self)
+        # Ensure API key is None
+        self.user.api_keys.openai = None
+
+    monkeypatch.setattr(GitCtxSettings, "__init__", mock_init)
+
+    # Don't set any config values
+    result = isolated_cli_runner.invoke(app, ["config", "list"])
+    assert result.exit_code == 0
+    # When only defaults exist, should show them (not "No configuration set")
+    # But if truly empty (no api keys), might show "No configuration set"
+    assert "search.limit" in result.stdout or "no configuration" in result.stdout.lower()

--- a/tests/unit/cli/test_index.py
+++ b/tests/unit/cli/test_index.py
@@ -1,18 +1,47 @@
 """Unit tests for index command."""
 
+import subprocess
+
+import pytest
+
 from gitctx.cli.main import app
 
 
-def test_index_command_exists(cli_runner):
+@pytest.fixture
+def mock_git_repo(isolated_cli_runner, tmp_path, monkeypatch):
+    """Create a minimal git repository for testing index command.
+
+    This creates an isolated git repo in tmp_path so tests don't pollute
+    the actual gitctx repository or user's config.
+    """
+    # Create repo directory
+    repo = tmp_path / "test_repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    # Initialize git
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+
+    # Add a file and commit
+    (repo / "test.py").write_text('print("hello")')
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=repo, check=True)
+
+    return isolated_cli_runner
+
+
+def test_index_command_exists(isolated_cli_runner):
     """Verify index command is registered."""
-    result = cli_runner.invoke(app, ["index", "--help"])
+    result = isolated_cli_runner.invoke(app, ["index", "--help"])
     assert result.exit_code == 0
     assert "Index the repository" in result.stdout
 
 
-def test_index_default_output(cli_runner):
+def test_index_default_output(mock_git_repo):
     """Verify default mode is terse (single line)."""
-    result = cli_runner.invoke(app, ["index"])
+    result = mock_git_repo.invoke(app, ["index"])
     assert result.exit_code == 0
     lines = [line for line in result.stdout.split("\n") if line.strip()]
     # Default should be 1 line: "Indexed N commits (M unique blobs) in Xs"
@@ -22,9 +51,9 @@ def test_index_default_output(cli_runner):
     assert "unique blobs" in result.stdout
 
 
-def test_index_verbose_flag(cli_runner):
+def test_index_verbose_flag(mock_git_repo):
     """Verify --verbose flag shows detailed output."""
-    result = cli_runner.invoke(app, ["index", "--verbose"])
+    result = mock_git_repo.invoke(app, ["index", "--verbose"])
     assert result.exit_code == 0
     # Verbose should have multiple sections
     assert "Walking commit graph" in result.stdout or "→" in result.stdout
@@ -33,34 +62,34 @@ def test_index_verbose_flag(cli_runner):
     assert len(lines) > 5  # Multiple lines in verbose mode
 
 
-def test_index_quiet_flag(cli_runner):
+def test_index_quiet_flag(mock_git_repo):
     """Verify --quiet flag suppresses output."""
-    result = cli_runner.invoke(app, ["index", "--quiet"])
+    result = mock_git_repo.invoke(app, ["index", "--quiet"])
     assert result.exit_code == 0
     # Quiet mode should have NO output on success
     assert result.stdout.strip() == ""
 
 
-def test_index_force_flag(cli_runner):
+def test_index_force_flag(mock_git_repo):
     """Verify --force flag is accepted."""
-    result = cli_runner.invoke(app, ["index", "--force"])
+    result = mock_git_repo.invoke(app, ["index", "--force"])
     assert result.exit_code == 0
     assert "Cleared existing index" in result.stdout or "force" in result.stdout.lower()
 
 
-def test_index_short_flags(cli_runner):
+def test_index_short_flags(mock_git_repo):
     """Verify -v, -q, -f short flags work."""
-    result = cli_runner.invoke(app, ["index", "-v", "-f"])
+    result = mock_git_repo.invoke(app, ["index", "-v", "-f"])
     assert result.exit_code == 0
 
-    result = cli_runner.invoke(app, ["index", "-q"])
+    result = mock_git_repo.invoke(app, ["index", "-q"])
     assert result.exit_code == 0
     assert result.stdout.strip() == ""
 
 
-def test_index_help_text(cli_runner):
+def test_index_help_text(isolated_cli_runner):
     """Verify help text includes all options."""
-    result = cli_runner.invoke(app, ["index", "--help"])
+    result = isolated_cli_runner.invoke(app, ["index", "--help"])
     assert "--verbose" in result.stdout
     assert "-v" in result.stdout
     assert "--quiet" in result.stdout
@@ -69,11 +98,14 @@ def test_index_help_text(cli_runner):
     assert "-f" in result.stdout
 
 
-def test_index_not_git_repository(cli_runner, tmp_path, monkeypatch):
-    """Verify index fails with proper error in non-git directory."""
-    # Change to non-git directory
-    monkeypatch.chdir(tmp_path)
+def test_index_not_git_repository(cli_runner):
+    """Verify index fails with proper error when run outside a git repository.
 
+    The cli_runner fixture (from tests/unit/conftest.py) automatically sets
+    the current directory to an isolated temporary path that is NOT a git
+    repository, ensuring this test verifies the "not a git repo" error path.
+    """
+    # cli_runner is already in a non-git temp directory (via isolated_cwd fixture)
     result = cli_runner.invoke(app, ["index"])
     assert result.exit_code == 3  # Exit code 3 = not a git repository
     # Error message goes to stderr (via console_err)

--- a/tests/unit/cli/test_tips.py
+++ b/tests/unit/cli/test_tips.py
@@ -1,0 +1,21 @@
+"""Unit tests for tips system."""
+
+from gitctx.cli.tips import show_tip
+
+
+def test_show_tip_with_undefined_command(capsys):
+    """Should gracefully handle commands with no tip defined."""
+    # Call with a command that has no tip defined
+    show_tip("nonexistent_command")
+    captured = capsys.readouterr()
+    # Should not crash - graceful return with no output
+    assert captured.out == ""
+
+
+def test_show_tip_with_valid_command(capsys):
+    """Should display tip for commands that have tips defined."""
+    # "config" has a tip defined in TIPS dictionary
+    show_tip("config")
+    captured = capsys.readouterr()
+    # Should show tip content
+    assert "Tip" in captured.out or "tip" in captured.out.lower()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,109 @@
+"""Unit test fixtures and helpers.
+
+This file contains fixtures specific to unit tests that don't require
+subprocess isolation. For E2E fixtures, see tests/e2e/conftest.py.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_env(temp_home: Path, monkeypatch):
+    """
+    Complete environment isolation for unit tests.
+
+    Provides isolated HOME directory and clears sensitive environment variables
+    that could interfere with config tests.
+
+    This consolidates the common pattern of:
+        monkeypatch.setenv("HOME", str(temp_home))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    Usage:
+        def test_something(isolated_env):
+            # temp_home is already set as HOME
+            # OPENAI_API_KEY is already cleared
+            config = UserConfig()  # Will use isolated HOME
+            ...
+
+    Returns:
+        Path: The isolated home directory (temp_home)
+
+    See also:
+    - temp_home: Creates isolated ~/.gitctx directory
+    - isolated_cli_runner: Full CLI isolation with working directory
+    """
+    monkeypatch.setenv("HOME", str(temp_home))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    return temp_home
+
+
+# === Fixture Factories ===
+
+
+@pytest.fixture
+def config_factory():
+    """
+    Factory for creating test config file content.
+
+    Returns a function that generates YAML config strings with customizable
+    settings. Useful for creating consistent test configs without repetition.
+
+    Returns:
+        callable: Factory function(**kwargs) -> str (YAML content)
+
+    Usage:
+        def test_custom_limit(config_factory, isolated_env):
+            config_yaml = config_factory(search_limit=20, embedding_model="text-embedding-3-small")
+            config_file = isolated_env / ".gitctx" / "config.yml"
+            config_file.write_text(config_yaml)
+            # Test with custom config...
+
+    Available parameters (all optional):
+    - search_limit: int = 10
+    - embedding_model: str = "text-embedding-3-large"
+    - chunk_size: int = 512
+    - chunk_overlap: int = 50
+    - openai_api_key: str | None = None
+
+    See also:
+    - isolated_env: For placing config files in isolated HOME
+    - temp_home: Direct access to temp home directory
+    """
+
+    def _make_config(
+        search_limit: int = 10,
+        embedding_model: str = "text-embedding-3-large",
+        chunk_size: int = 512,
+        chunk_overlap: int = 50,
+        openai_api_key: str | None = None,
+    ) -> str:
+        """Generate YAML config content with specified settings."""
+        config_dict = {
+            "search": {"limit": search_limit},
+            "model": {
+                "embedding": embedding_model,
+                "chunk_size": chunk_size,
+                "chunk_overlap": chunk_overlap,
+            },
+        }
+
+        # Add API key section if provided
+        if openai_api_key:
+            config_dict["api_keys"] = {"openai": openai_api_key}
+
+        # Convert to YAML manually (avoid PyYAML dependency in test utils)
+        lines = []
+        for section, values in config_dict.items():
+            lines.append(f"{section}:")
+            if isinstance(values, dict):
+                for key, val in values.items():
+                    lines.append(f"  {key}: {val}")
+            else:
+                lines.append(f"  {values}")
+
+        return "\n".join(lines) + "\n"
+
+    return _make_config

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -1,0 +1,465 @@
+"""Unit tests for GitCtxSettings aggregator and routing logic."""
+
+import contextlib
+
+
+class TestGitCtxSettingsRouting:
+    """Test GitCtxSettings routes config by key pattern."""
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_gitctx_settings_routes_api_keys_to_user(self, temp_home, monkeypatch):
+        """API keys should be routed to user config."""
+        from gitctx.core.config import GitCtxSettings
+
+        # Setup
+        monkeypatch.setenv("HOME", str(temp_home))
+        # Clear OPENAI_API_KEY to prevent env var interference
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        # Create user config
+        config_file = temp_home / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: sk-test123\n")
+
+        # Act
+        settings = GitCtxSettings()
+        value = settings.get("api_keys.openai")
+
+        # Assert - routed to user config
+        assert value == "sk-test123"
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_gitctx_settings_routes_settings_to_repo(self, tmp_path, monkeypatch):
+        """Repo settings should be routed to repo config."""
+        from gitctx.core.config import GitCtxSettings
+
+        # Setup
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        # Clear OPENAI_API_KEY to prevent env var interference
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        # Create repo config
+        config_dir = tmp_path / ".gitctx"
+        config_dir.mkdir()
+        config_file = config_dir / "config.yml"
+        config_file.write_text("search:\n  limit: 25\n")
+
+        # Act
+        settings = GitCtxSettings()
+        value = settings.get("search.limit")
+
+        # Assert - routed to repo config
+        assert value == 25
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_set_api_key_persists_to_user_config(self, temp_home, monkeypatch):
+        """Setting API key should save to user config file."""
+        from gitctx.core.config import GitCtxSettings
+
+        # Setup
+        monkeypatch.setenv("HOME", str(temp_home))
+        # Clear OPENAI_API_KEY to prevent env var interference
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        # Act
+        settings = GitCtxSettings()
+        settings.set("api_keys.openai", "sk-new123")
+
+        # Assert - saved to user config
+        config_file = temp_home / ".gitctx" / "config.yml"
+        assert config_file.exists()
+        content = config_file.read_text()
+        assert "sk-new123" in content
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_set_repo_setting_persists_to_repo_config(self, tmp_path, monkeypatch):
+        """Setting repo setting should save to repo config file."""
+        from gitctx.core.config import GitCtxSettings
+
+        # Setup
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        # Clear OPENAI_API_KEY to prevent env var interference
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        # Act
+        settings = GitCtxSettings()
+        settings.set("search.limit", 30)
+
+        # Assert - saved to repo config
+        config_file = tmp_path / ".gitctx" / "config.yml"
+        assert config_file.exists()
+        content = config_file.read_text()
+        assert "limit: 30" in content
+
+
+class TestGetSource:
+    """Test get_source() method returns correct source indicators."""
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_get_source_openai_api_key_env_var(self, temp_home, monkeypatch):
+        """Should detect OPENAI_API_KEY env var as source."""
+        from gitctx.core.config import GitCtxSettings
+
+        # Setup
+        monkeypatch.setenv("HOME", str(temp_home))
+        # Clear OPENAI_API_KEY to prevent env var interference
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env123")
+
+        # Act
+        settings = GitCtxSettings()
+        source = settings.get_source("api_keys.openai")
+
+        # Assert
+        assert source == "(from OPENAI_API_KEY)"
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_get_source_user_config(self, temp_home, monkeypatch):
+        """Should detect user config file as source."""
+        from gitctx.core.config import GitCtxSettings
+
+        # Setup
+        monkeypatch.setenv("HOME", str(temp_home))
+        # Clear OPENAI_API_KEY to prevent env var interference
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        # Create user config
+        config_file = temp_home / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: sk-file123\n")
+
+        # Act
+        settings = GitCtxSettings()
+        source = settings.get_source("api_keys.openai")
+
+        # Assert
+        assert source == "(from user config)"
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_get_source_gitctx_env_var(self, tmp_path, monkeypatch):
+        """Should detect GITCTX_* env var as source."""
+        from gitctx.core.config import GitCtxSettings
+
+        # Setup
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        # Clear OPENAI_API_KEY to prevent env var interference
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("GITCTX_SEARCH__LIMIT", "40")
+
+        # Act
+        settings = GitCtxSettings()
+        source = settings.get_source("search.limit")
+
+        # Assert
+        assert source == "(from GITCTX_SEARCH__LIMIT)"
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_get_source_repo_config(self, tmp_path, monkeypatch):
+        """Should detect repo config file as source."""
+        from gitctx.core.config import GitCtxSettings
+
+        # Setup
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        # Clear OPENAI_API_KEY to prevent env var interference
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        # Create repo config
+        config_dir = tmp_path / ".gitctx"
+        config_dir.mkdir()
+        config_file = config_dir / "config.yml"
+        config_file.write_text("search:\n  limit: 25\n")
+
+        # Act
+        settings = GitCtxSettings()
+        source = settings.get_source("search.limit")
+
+        # Assert
+        assert source == "(from repo config)"
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_get_source_default(self, tmp_path, monkeypatch):
+        """Should detect default as source when no override."""
+        from gitctx.core.config import GitCtxSettings
+
+        # Setup
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        # Clear OPENAI_API_KEY to prevent env var interference
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        # Act - no config files or env vars
+        settings = GitCtxSettings()
+        source = settings.get_source("search.limit")
+
+        # Assert
+        assert source == "(default)"
+
+
+class TestInitRepoConfig:
+    """Test init_repo_config() function."""
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_init_repo_config_creates_structure(self, tmp_path, monkeypatch):
+        """Should create .gitctx/ directory with config.yml and .gitignore."""
+        from gitctx.core.config import init_repo_config
+
+        # Setup
+        monkeypatch.chdir(tmp_path)
+
+        # Act
+        init_repo_config()
+
+        # Assert - directory created
+        assert (tmp_path / ".gitctx").exists()
+        assert (tmp_path / ".gitctx").is_dir()
+
+        # Assert - config.yml created with defaults
+        config_file = tmp_path / ".gitctx" / "config.yml"
+        assert config_file.exists()
+        content = config_file.read_text()
+        assert "search:" in content
+        assert "limit: 10" in content
+        assert "index:" in content
+        assert "model:" in content
+
+        # Assert - .gitignore created
+        gitignore = tmp_path / ".gitctx" / ".gitignore"
+        assert gitignore.exists()
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_gitignore_content(self, tmp_path, monkeypatch):
+        """Should create .gitignore with correct content."""
+        from gitctx.core.config import init_repo_config
+
+        # Setup
+        monkeypatch.chdir(tmp_path)
+
+        # Act
+        init_repo_config()
+
+        # Assert - .gitignore has correct content
+        gitignore = tmp_path / ".gitctx" / ".gitignore"
+        content = gitignore.read_text()
+
+        # Check for comments (important for user understanding)
+        assert "# LanceDB vector database - never commit" in content
+        assert "# Application logs - never commit" in content
+
+        # Check for patterns
+        assert "db/" in content
+        assert "logs/" in content
+        assert "*.log" in content
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_init_repo_config_idempotent(self, tmp_path, monkeypatch):
+        """Should be safe to call multiple times."""
+        from gitctx.core.config import init_repo_config
+
+        # Setup
+        monkeypatch.chdir(tmp_path)
+
+        # Act - call twice
+        init_repo_config()
+        init_repo_config()
+
+        # Assert - still works, no errors
+        assert (tmp_path / ".gitctx" / "config.yml").exists()
+        assert (tmp_path / ".gitctx" / ".gitignore").exists()
+
+
+class TestSecuritySeparation:
+    """Test that user/repo configs are properly separated."""
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_api_keys_never_in_repo_config(self, temp_home, tmp_path, monkeypatch):
+        """API keys should NEVER be saved to repo config."""
+        from gitctx.core.config import GitCtxSettings
+
+        # Setup
+        monkeypatch.setenv("HOME", str(temp_home))
+        # Clear OPENAI_API_KEY to prevent env var interference
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        # Act - set API key
+        settings = GitCtxSettings()
+        settings.set("api_keys.openai", "sk-secret123")
+
+        # Assert - API key in user config
+        user_config = temp_home / ".gitctx" / "config.yml"
+        assert user_config.exists()
+        assert "sk-secret123" in user_config.read_text()
+
+        # Assert - API key NOT in repo config (if it exists)
+        repo_config = tmp_path / ".gitctx" / "config.yml"
+        if repo_config.exists():
+            assert "sk-secret123" not in repo_config.read_text()
+            assert "api_keys" not in repo_config.read_text()
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_repo_settings_never_in_user_config(self, temp_home, tmp_path, monkeypatch):
+        """Repo settings should NEVER be saved to user config."""
+        from gitctx.core.config import GitCtxSettings
+
+        # Setup
+        monkeypatch.setenv("HOME", str(temp_home))
+        # Clear OPENAI_API_KEY to prevent env var interference
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        # Act - set repo setting
+        settings = GitCtxSettings()
+        settings.set("search.limit", 30)
+
+        # Assert - setting in repo config
+        repo_config = tmp_path / ".gitctx" / "config.yml"
+        assert repo_config.exists()
+        assert "limit: 30" in repo_config.read_text()
+
+        # Assert - setting NOT in user config (if it exists)
+        user_config = temp_home / ".gitctx" / "config.yml"
+        if user_config.exists():
+            assert "search" not in user_config.read_text()
+            assert "limit" not in user_config.read_text()
+
+
+class TestConfigErrorHandling:
+    """Test error handling in config operations."""
+
+    def test_get_from_user_handles_missing_intermediate(self, temp_home, monkeypatch):
+        """Test handling of None intermediate values in user config."""
+        from gitctx.core.config import GitCtxSettings
+
+        monkeypatch.setenv("HOME", str(temp_home))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        settings = GitCtxSettings()
+        # Accessing a nonexistent nested key returns None
+        # (getattr with default=None prevents AttributeError)
+        result = settings.get("api_keys.nonexistent")
+        assert result is None
+
+    def test_set_in_repo_invalid_key_format(self, temp_home, monkeypatch, tmp_path):
+        """Test setting repo config with invalid key format."""
+        from gitctx.core.config import GitCtxSettings
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(temp_home))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        settings = GitCtxSettings()
+        # Try to set with wrong number of parts
+        with contextlib.suppress(AttributeError):
+            settings.set("invalid", "value")
+
+    def test_get_source_edge_case_matching_default(self, tmp_path, monkeypatch):
+        """Test get_source when value exists but matches default."""
+        from gitctx.core.config import GitCtxSettings
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        # Create repo config with default value
+        config_file = tmp_path / ".gitctx" / "config.yml"
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        # Set to default value (limit 10 is default)
+        config_file.write_text("search:\n  limit: 10\n")
+
+        settings = GitCtxSettings()
+        source = settings.get_source("search.limit")
+        # When value matches default, source detection has an edge case path
+        assert source in ["(default)", "(from repo config)"]
+
+    def test_get_from_user_returns_secret_value(self, temp_home, monkeypatch):
+        """Test _get_from_user returns secret value for MaskedSecretStr."""
+        from gitctx.core.config import GitCtxSettings
+
+        monkeypatch.setenv("HOME", str(temp_home))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        # Create user config with API key
+        config_file = temp_home / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: sk-secret789\n")
+
+        settings = GitCtxSettings()
+        # This should exercise the hasattr(current, "get_secret_value") path
+        value = settings.get("api_keys.openai")
+        assert value == "sk-secret789"
+
+    def test_get_from_repo_returns_none_for_missing(self, tmp_path, monkeypatch):
+        """Test _get_from_repo returns None for missing intermediate values."""
+        from gitctx.core.config import GitCtxSettings
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        settings = GitCtxSettings()
+        # Try to get a nonexistent nested value
+        result = settings.get("search.nonexistent")
+        assert result is None
+
+    def test_get_source_user_config_yaml_error(self, temp_home, monkeypatch):
+        """Test get_source handles YAML parsing errors in user config."""
+        from gitctx.core.config import GitCtxSettings
+
+        monkeypatch.setenv("HOME", str(temp_home))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        # Create valid user config first so initialization succeeds
+        config_file = temp_home / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: sk-test123\n")
+
+        settings = GitCtxSettings()
+
+        # Now corrupt the file AFTER initialization but BEFORE get_source reads it
+        config_file.write_text("api_keys:\n  openai: [unclosed")
+
+        # Should handle YAML error gracefully and return default
+        source = settings.get_source("api_keys.openai")
+        assert source == "(default)"
+
+    def test_get_source_repo_config_missing_nested_key(self, tmp_path, monkeypatch):
+        """Test get_source when nested dict navigation fails in repo config."""
+        from gitctx.core.config import GitCtxSettings
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        # Create repo config without the searched key
+        config_dir = tmp_path / ".gitctx"
+        config_dir.mkdir()
+        config_file = config_dir / "config.yml"
+        config_file.write_text("search:\n  rerank: true\n")
+
+        settings = GitCtxSettings()
+        # Should return default when nested key missing
+        source = settings.get_source("index.chunk_size")
+        assert source == "(default)"
+
+    def test_get_source_repo_config_yaml_error(self, tmp_path, monkeypatch):
+        """Test get_source handles YAML parsing errors in repo config."""
+        from gitctx.core.config import GitCtxSettings
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        # Create valid repo config first so initialization succeeds
+        config_dir = tmp_path / ".gitctx"
+        config_dir.mkdir()
+        config_file = config_dir / "config.yml"
+        config_file.write_text("search:\n  limit: 20\n")
+
+        settings = GitCtxSettings()
+
+        # Now corrupt the file AFTER initialization but BEFORE get_source reads it
+        config_file.write_text("search:\n  limit: {invalid yaml")
+
+        # Should handle YAML error gracefully and return default
+        source = settings.get_source("search.limit")
+        assert source == "(default)"

--- a/tests/unit/core/test_repo_config.py
+++ b/tests/unit/core/test_repo_config.py
@@ -1,0 +1,325 @@
+"""Unit tests for repo configuration (team settings only)."""
+
+import os
+
+import pytest
+
+
+class TestRepoConfigLoading:
+    """Test repo config loading from various sources."""
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_repo_config_loads_from_yaml(self, tmp_path, monkeypatch):
+        """Config should load settings from YAML file."""
+        from gitctx.core.repo_config import RepoConfig
+
+        # Setup - change to test directory
+        monkeypatch.chdir(tmp_path)
+
+        # Create config file
+        config_dir = tmp_path / ".gitctx"
+        config_dir.mkdir()
+        config_file = config_dir / "config.yml"
+        config_file.write_text("search:\n  limit: 20\n  rerank: false\n")
+
+        # Act
+        config = RepoConfig()
+
+        # Assert
+        assert config.search.limit == 20
+        assert config.search.rerank is False
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_gitctx_env_var_overrides_yaml(self, tmp_path, monkeypatch):
+        """GITCTX_* env vars should override YAML."""
+        from gitctx.core.repo_config import RepoConfig
+
+        # Setup
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("GITCTX_SEARCH__LIMIT", "30")
+
+        # Create config file with different value
+        config_dir = tmp_path / ".gitctx"
+        config_dir.mkdir()
+        config_file = config_dir / "config.yml"
+        config_file.write_text("search:\n  limit: 10\n")
+
+        # Act
+        config = RepoConfig()
+
+        # Assert - env var wins
+        assert config.search.limit == 30
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_yaml_used_when_no_env_vars(self, tmp_path, monkeypatch):
+        """YAML should be used when no env vars are set."""
+        from gitctx.core.repo_config import RepoConfig
+
+        # Setup
+        monkeypatch.chdir(tmp_path)
+
+        # Create config file
+        config_dir = tmp_path / ".gitctx"
+        config_dir.mkdir()
+        config_file = config_dir / "config.yml"
+        config_file.write_text("search:\n  limit: 25\n")
+
+        # Act
+        config = RepoConfig()
+
+        # Assert
+        assert config.search.limit == 25
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_defaults_used_when_no_config(self, tmp_path, monkeypatch):
+        """Defaults should be used when no config file exists."""
+        from gitctx.core.repo_config import RepoConfig
+
+        # Setup
+        monkeypatch.chdir(tmp_path)
+
+        # Act - no config file
+        config = RepoConfig()
+
+        # Assert - defaults
+        assert config.search.limit == 10
+        assert config.search.rerank is True
+        assert config.index.chunk_size == 1000
+        assert config.index.chunk_overlap == 200
+        assert config.model.embedding == "text-embedding-3-large"
+
+
+class TestRepoConfigValidation:
+    """Test Pydantic validation of configuration values."""
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_config_validates_types(self):
+        """Config should validate type correctness."""
+        from gitctx.core.repo_config import RepoConfig
+
+        # Act
+        config = RepoConfig(search={"limit": 20})
+
+        # Assert
+        assert config.search.limit == 20
+        assert isinstance(config.search.limit, int)
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_config_rejects_invalid_types(self):
+        """Config should reject invalid type values."""
+        from pydantic import ValidationError
+
+        from gitctx.core.repo_config import RepoConfig
+
+        # Assert
+        with pytest.raises(ValidationError) as exc_info:
+            RepoConfig(search={"limit": "invalid"})
+
+        assert "validation error" in str(exc_info.value).lower()
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_config_validates_constraints(self):
+        """Config should validate field constraints."""
+        from pydantic import ValidationError
+
+        from gitctx.core.repo_config import RepoConfig
+
+        # Test negative limit (should fail - must be > 0)
+        with pytest.raises(ValidationError):
+            RepoConfig(search={"limit": -5})
+
+        # Test limit too high (should fail - must be <= 100)
+        with pytest.raises(ValidationError):
+            RepoConfig(search={"limit": 150})
+
+
+class TestRepoConfigPersistence:
+    """Test saving repo configuration."""
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_repo_config_saves_to_yaml(self, tmp_path, monkeypatch):
+        """Config.save() should persist to YAML file with 0644 permissions."""
+        from gitctx.core.repo_config import RepoConfig
+
+        # Setup
+        monkeypatch.chdir(tmp_path)
+
+        # Create config
+        config = RepoConfig()
+        config.search.limit = 25
+
+        # Act
+        config.save()
+
+        # Assert - file exists
+        config_file = tmp_path / ".gitctx" / "config.yml"
+        assert config_file.exists()
+
+        # Assert - content is correct
+        content = config_file.read_text()
+        assert "limit: 25" in content
+
+        # Assert - file permissions are 0644 (Unix) or just readable (Windows)
+        import stat
+
+        from tests.conftest import is_windows
+
+        if is_windows():
+            # Windows uses ACLs, not Unix permissions - just verify file is accessible
+            assert config_file.exists()
+            assert os.access(config_file, os.R_OK)
+        else:
+            # Unix: Check exact permissions
+            mode = config_file.stat().st_mode
+            assert stat.S_IMODE(mode) == 0o644
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_repo_config_creates_directory(self, tmp_path, monkeypatch):
+        """Config.save() should create .gitctx/ if it doesn't exist."""
+        from gitctx.core.repo_config import RepoConfig
+
+        # Setup
+        monkeypatch.chdir(tmp_path)
+
+        # Verify directory doesn't exist
+        assert not (tmp_path / ".gitctx").exists()
+
+        # Act
+        config = RepoConfig()
+        config.save()
+
+        # Assert - directory and file created
+        assert (tmp_path / ".gitctx").exists()
+        assert (tmp_path / ".gitctx" / "config.yml").exists()
+
+
+class TestErrorHandling:
+    """Test error handling for malformed YAML and permission issues."""
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_malformed_yaml_error(self, tmp_path, monkeypatch):
+        """Clear error message for malformed YAML."""
+        from gitctx.core.repo_config import RepoConfig
+
+        # Setup
+        monkeypatch.chdir(tmp_path)
+
+        # Create invalid YAML
+        config_dir = tmp_path / ".gitctx"
+        config_dir.mkdir()
+        config_file = config_dir / "config.yml"
+        config_file.write_text("search:\n  limit: [unclosed")
+
+        # Act & Assert - should raise error
+        with pytest.raises(Exception) as exc_info:
+            RepoConfig()
+
+        # Error message should be helpful
+        assert "parsing" in str(exc_info.value).lower() or "yaml" in str(exc_info.value).lower()
+
+    # @pytest.mark.skip(reason="RED phase - module doesn't exist yet")
+    def test_permission_denied_error(self, tmp_path, monkeypatch):
+        """Clear error message for permission denied."""
+        import subprocess
+
+        from tests.conftest import is_windows
+
+        from gitctx.core.repo_config import RepoConfig
+
+        # Setup
+        monkeypatch.chdir(tmp_path)
+
+        # Create read-only directory
+        config_dir = tmp_path / ".gitctx"
+        config_dir.mkdir()
+
+        if is_windows():
+            # Windows: Use icacls to deny write permission
+            config_file = config_dir / "config.yml"
+            config_file.touch()  # Create file first
+            # Remove write permissions using icacls
+            # NOTE: Using *S-1-1-0 (Everyone) is safe here because:
+            # - We're only modifying permissions on isolated tmp_path test files
+            # - Permissions are restored immediately after the test
+            # - pytest automatically cleans up tmp_path after test completion
+            subprocess.run(
+                ["icacls", str(config_file), "/deny", "*S-1-1-0:(W)"],
+                check=True,
+                capture_output=True,
+            )
+
+            # Act & Assert - should raise PermissionError on write
+            with pytest.raises(PermissionError):
+                config = RepoConfig()
+                config.save()
+
+            # Cleanup: restore permissions so pytest can delete temp dir
+            subprocess.run(
+                ["icacls", str(config_file), "/grant", "*S-1-1-0:(F)"],
+                check=True,
+                capture_output=True,
+            )
+        else:
+            # Unix: Use chmod
+            config_dir.chmod(0o444)  # Read-only
+
+            # Act & Assert - should raise PermissionError
+            with pytest.raises(PermissionError):
+                config = RepoConfig()
+                config.save()
+
+
+class TestEdgeCasesUnicode:
+    """Test Unicode handling - real scenario: international users."""
+
+    def test_unicode_emoji_in_model_name(self, tmp_path, monkeypatch):
+        """Model name can contain emoji."""
+        from gitctx.core.repo_config import RepoConfig
+
+        monkeypatch.chdir(tmp_path)
+        config = RepoConfig()
+        config.model.embedding = "text-embedding-🌍-large"
+        config.save()
+
+        # Reload and verify
+        config2 = RepoConfig()
+        assert config2.model.embedding == "text-embedding-🌍-large"
+
+
+class TestFileCorruption:
+    """Test file corruption - real scenario: editor crash, disk full."""
+
+    def test_truncated_yaml_shows_clear_error(self, tmp_path, monkeypatch):
+        """Truncated YAML shows clear error message."""
+        from gitctx.core.repo_config import RepoConfig
+
+        monkeypatch.chdir(tmp_path)
+        config_dir = tmp_path / ".gitctx"
+        config_dir.mkdir()
+        config_file = config_dir / "config.yml"
+        # Truncated in middle of value
+        config_file.write_text("search:\n  lim")
+
+        # Should raise with parse/yaml/validation error
+        with pytest.raises(Exception) as exc:
+            RepoConfig()
+        error_msg = str(exc.value).lower()
+        # Pydantic validation error is also acceptable (clear error message)
+        assert any(word in error_msg for word in ["parse", "yaml", "scan", "validation"])
+
+    def test_malformed_yaml_shows_clear_error(self, tmp_path, monkeypatch):
+        """Malformed YAML shows helpful error message."""
+        from pydantic import ValidationError
+
+        from gitctx.core.repo_config import RepoConfig
+
+        monkeypatch.chdir(tmp_path)
+        config_dir = tmp_path / ".gitctx"
+        config_dir.mkdir()
+        config_file = config_dir / "config.yml"
+        # List instead of dict - wrong type
+        config_file.write_text("search:\n- wrong_type\n")
+
+        # Should raise ValidationError (Pydantic catches wrong type)
+        with pytest.raises(ValidationError):
+            RepoConfig()

--- a/tests/unit/core/test_user_config.py
+++ b/tests/unit/core/test_user_config.py
@@ -1,0 +1,311 @@
+"""Unit tests for user configuration (API keys only)."""
+
+import os
+
+
+class TestUserConfigLoading:
+    """Test user config loading from various sources."""
+
+    def test_user_config_loads_from_yaml(self, isolated_env):
+        """Config should load API keys from YAML file.
+
+        NOTE: isolated_env provides temp_home with .gitctx/ subdirectory!
+        """
+        from gitctx.core.user_config import UserConfig
+
+        # isolated_env already sets HOME and clears OPENAI_API_KEY
+        # Write config (isolated_env / ".gitctx" already exists!)
+        config_file = isolated_env / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: sk-file123\n")
+
+        # Act
+        config = UserConfig()
+
+        # Assert - will FAIL (no implementation)
+        assert config.api_keys.openai.get_secret_value() == "sk-file123"
+
+    def test_openai_api_key_env_var_precedence(self, temp_home, monkeypatch):
+        """OPENAI_API_KEY should override YAML."""
+        from gitctx.core.user_config import UserConfig
+
+        # Setup
+        monkeypatch.setenv("HOME", str(temp_home))
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-provider789")
+
+        # Write config with different value
+        config_file = temp_home / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: sk-file123\n")
+
+        # Act
+        config = UserConfig()
+
+        # Assert - OPENAI_API_KEY wins
+        assert config.api_keys.openai.get_secret_value() == "sk-provider789"
+
+    def test_yaml_used_when_no_env_vars(self, isolated_env):
+        """YAML should be used when no env vars are set."""
+        from gitctx.core.user_config import UserConfig
+
+        # isolated_env provides HOME and clears OPENAI_API_KEY
+        # Write config
+        config_file = isolated_env / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: sk-file123\n")
+
+        # Act
+        config = UserConfig()
+
+        # Assert
+        assert config.api_keys.openai.get_secret_value() == "sk-file123"
+
+    def test_user_config_handles_missing_file(self, isolated_env):
+        """Config should use defaults when YAML file doesn't exist.
+
+        Note: isolated_env fixture is required for test isolation (sets HOME, clears env vars)
+        even though it's not directly referenced in the test body.
+        """
+        from gitctx.core.user_config import UserConfig
+
+        # isolated_env provides HOME and clears OPENAI_API_KEY (used implicitly)
+        # Act - no config file exists
+        config = UserConfig()
+
+        # Assert - should use None default
+        assert config.api_keys.openai is None
+
+    def test_insecure_permissions_shows_warning(self, isolated_env, capsys):
+        """Config should warn when file has insecure permissions."""
+
+        from tests.conftest import is_windows
+
+        from gitctx.core.user_config import UserConfig
+
+        if is_windows():
+            # Skip on Windows - permissions work differently
+            import pytest
+
+            pytest.skip("Permission checks not applicable on Windows")
+
+        # isolated_env provides HOME and clears OPENAI_API_KEY
+        # Write config with insecure permissions
+        config_file = isolated_env / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: sk-test123\n")
+        config_file.chmod(0o644)  # Insecure: readable by group and others
+
+        # Act - loading config should show warning
+        UserConfig()
+
+        # Assert - warning displayed on stderr (not stdout)
+        captured = capsys.readouterr()
+        assert "insecure permissions" in captured.err.lower()
+        assert "644" in captured.err
+        assert "600" in captured.err
+
+    def test_windows_acl_file_permissions(self, isolated_env):
+        """Windows: User config file should be accessible by owner only."""
+        import os
+        import platform
+
+        import pytest
+        from pydantic import SecretStr
+
+        from gitctx.core.user_config import UserConfig
+
+        if platform.system() != "Windows":
+            pytest.skip("Windows-only test")
+
+        # Create and save config
+        config = UserConfig()
+        config.api_keys.openai = SecretStr("sk-test123")
+        config.save()
+
+        config_file = isolated_env / ".gitctx" / "config.yml"
+        assert config_file.exists()
+
+        # Verify owner can read/write (Windows doesn't use Unix 0600)
+        assert os.access(config_file, os.R_OK), "Config file should be readable by owner"
+        assert os.access(config_file, os.W_OK), "Config file should be writable by owner"
+
+    def test_windows_userprofile_path_expansion(self):
+        """Windows: %USERPROFILE% should expand correctly via Path.home()."""
+        import platform
+        from pathlib import Path
+
+        import pytest
+
+        if platform.system() != "Windows":
+            pytest.skip("Windows-only test")
+
+        # Path.home() should work on Windows
+        home = Path.home()
+        assert home.exists(), "User home directory should exist"
+        assert "Users" in str(home), "Windows home path should contain 'Users'"
+
+        # Config path should use Windows separators (or accept both)
+        config_path = home / ".gitctx" / "config.yml"
+        path_str = str(config_path)
+        assert "\\" in path_str or "/" in path_str, "Path should use valid separators"
+
+
+class TestUserConfigPersistence:
+    """Test saving user configuration."""
+
+    def test_user_config_saves_to_yaml(self, isolated_env):
+        """Config.save() should persist to YAML file with 0600 permissions."""
+        from pydantic import SecretStr
+
+        from gitctx.core.user_config import UserConfig
+
+        # isolated_env provides HOME and clears OPENAI_API_KEY
+        # Create config
+        config = UserConfig()
+        config.api_keys.openai = SecretStr("sk-test123")
+
+        # Act
+        config.save()
+
+        # Assert - file exists
+        config_file = isolated_env / ".gitctx" / "config.yml"
+        assert config_file.exists()
+
+        # Assert - content is correct
+        content = config_file.read_text()
+        assert "openai" in content
+        assert "sk-test123" in content
+
+        # Assert - file permissions are 0600 (Unix) or just readable/writable (Windows)
+        import stat
+
+        from tests.conftest import is_windows
+
+        if is_windows():
+            # Windows uses ACLs, not Unix permissions - just verify file is accessible
+            assert config_file.exists()
+            assert os.access(config_file, os.R_OK | os.W_OK)
+        else:
+            # Unix: Check exact permissions
+            mode = config_file.stat().st_mode
+            assert stat.S_IMODE(mode) == 0o600
+
+    def test_user_config_directory_already_exists(self, temp_home, monkeypatch):
+        """Config should work when ~/.gitctx/ already exists."""
+        from gitctx.core.user_config import UserConfig
+
+        # Setup
+        monkeypatch.setenv("HOME", str(temp_home))
+        # Clear OPENAI_API_KEY to prevent env var interference
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        # Verify directory exists (created by temp_home fixture)
+        assert (temp_home / ".gitctx").exists()
+        assert (temp_home / ".gitctx").is_dir()
+
+        # Act - save should work even with existing directory
+        config = UserConfig()
+        config.save()
+
+        # Assert
+        assert (temp_home / ".gitctx" / "config.yml").exists()
+
+
+class TestSecretStrMasking:
+    """Test SecretStr automatically masks API keys."""
+
+    def test_secret_str_masks_api_keys(self):
+        """SecretStr should mask API keys in string representation."""
+        from gitctx.core.user_config import ApiKeys
+
+        # Act
+        api_keys = ApiKeys(openai="sk-test123456")
+
+        # Assert - masked in string repr
+        assert "sk-test123456" not in str(api_keys)
+        assert "sk-test123456" not in repr(api_keys)
+
+        # Assert - can retrieve with get_secret_value()
+        assert api_keys.openai.get_secret_value() == "sk-test123456"
+
+
+class TestCrossPlatform:
+    """Test cross-platform path handling."""
+
+    def test_user_config_windows_path(self, temp_home, monkeypatch):
+        """Path.home() should work correctly on all platforms."""
+        from gitctx.core.user_config import UserConfig
+
+        # Setup
+        monkeypatch.setenv("HOME", str(temp_home))
+        # Clear OPENAI_API_KEY to prevent env var interference
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        # Write a config file
+        config_file = temp_home / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: sk-test\n")
+
+        # Act - config should load from platform-independent path
+        config = UserConfig()
+
+        # Assert - config loaded successfully from correct path
+        assert config.api_keys.openai is not None
+        assert config.api_keys.openai.get_secret_value() == "sk-test"
+
+
+class TestEdgeCasesUnicode:
+    """Test Unicode handling - real scenario: international users."""
+
+    def test_unicode_chinese_in_api_key(self, isolated_env):
+        """API key can contain Chinese characters."""
+        import platform
+
+        import pytest
+
+        if platform.system() == "Windows":
+            pytest.skip("Unicode test skipped on Windows (YAML encoding differences)")
+
+        from gitctx.core.user_config import UserConfig
+
+        config_file = isolated_env / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: 密钥-sk-abc123\n", encoding="utf-8")
+
+        config = UserConfig()
+        assert config.api_keys.openai.get_secret_value() == "密钥-sk-abc123"
+
+    def test_unicode_rtl_in_api_key(self, isolated_env):
+        """API key can contain RTL (Arabic) text."""
+        import platform
+
+        import pytest
+
+        if platform.system() == "Windows":
+            pytest.skip("Unicode test skipped on Windows (YAML encoding differences)")
+
+        from gitctx.core.user_config import UserConfig
+
+        config_file = isolated_env / ".gitctx" / "config.yml"
+        config_file.write_text("api_keys:\n  openai: sk-العربية123\n", encoding="utf-8")
+
+        config = UserConfig()
+        assert config.api_keys.openai.get_secret_value() == "sk-العربية123"
+
+
+class TestFilesystemEdgeCases:
+    """Test filesystem edge cases - real scenario: first-time user."""
+
+    def test_save_creates_missing_parent_directories(self, tmp_path, monkeypatch):
+        """save() creates ~/.gitctx/ if missing."""
+        from pydantic import SecretStr
+
+        from gitctx.core.user_config import UserConfig
+
+        # Set HOME to a path that doesn't exist yet
+        new_home = tmp_path / "nonexistent" / "user" / "home"
+        monkeypatch.setenv("HOME", str(new_home))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        # Should create all parent directories
+        config = UserConfig()
+        config.api_keys.openai = SecretStr("sk-test123")
+        config.save()
+
+        config_file = new_home / ".gitctx" / "config.yml"
+        assert config_file.exists()
+        assert "sk-test123" in config_file.read_text()

--- a/tests/unit/test_fixtures.py
+++ b/tests/unit/test_fixtures.py
@@ -8,9 +8,20 @@ tests here to verify behavior.
 
 def test_git_isolation_base(git_isolation_base: dict[str, str]) -> None:
     """Verify git isolation base contains security vars."""
-    assert git_isolation_base["GIT_SSH_COMMAND"] == "/bin/false"
+    from tests.conftest import get_platform_null_device, get_platform_ssh_command
+
+    expected_ssh_cmd = get_platform_ssh_command()
+    expected_null_device = get_platform_null_device()
+
+    assert git_isolation_base["GIT_SSH_COMMAND"] == expected_ssh_cmd
     assert git_isolation_base["SSH_AUTH_SOCK"] == ""
-    assert git_isolation_base["GNUPGHOME"] == "/dev/null"
+
+    # GNUPGHOME should be an isolated temp directory, not user's real .gnupg
+    gnupghome = git_isolation_base["GNUPGHOME"]
+    assert "gnupg_isolated" in gnupghome, "GNUPGHOME should be isolated temp directory"
+
+    assert git_isolation_base["GIT_CONFIG_GLOBAL"] == expected_null_device
+    assert git_isolation_base["GIT_CONFIG_SYSTEM"] == expected_null_device
     assert git_isolation_base["GIT_TERMINAL_PROMPT"] == "0"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "argcomplete"
 version = "3.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -293,6 +302,8 @@ name = "gitctx"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "pydantic" },
+    { name = "pydantic-settings", extra = ["yaml"] },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "shellingham" },
@@ -321,6 +332,8 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "poethepoet", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.6.0" },
+    { name = "pydantic", specifier = ">=2.11.0" },
+    { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.11.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-bdd", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
@@ -645,6 +658,105 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.11.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/54/ecab642b3bed45f7d5f59b38443dcb36ef50f85af192e6ece103dbfe9587/pydantic-2.11.10.tar.gz", hash = "sha256:dc280f0982fbda6c38fada4e476dc0a4f3aeaf9c6ad4c28df68a666ec3c61423", size = 788494, upload-time = "2025-10-04T10:40:41.338Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl", hash = "sha256:802a655709d49bd004c31e865ef37da30b540786a46bfce02333e0e24b5fe29a", size = 444823, upload-time = "2025-10-04T10:40:39.055Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.33.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/8d/71db63483d518cbbf290261a1fc2839d17ff89fce7089e08cad07ccfce67/pydantic_core-2.33.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4c5b0a576fb381edd6d27f0a85915c6daf2f8138dc5c267a57c08a62900758c7", size = 2028584, upload-time = "2025-04-23T18:31:03.106Z" },
+    { url = "https://files.pythonhosted.org/packages/24/2f/3cfa7244ae292dd850989f328722d2aef313f74ffc471184dc509e1e4e5a/pydantic_core-2.33.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e799c050df38a639db758c617ec771fd8fb7a5f8eaaa4b27b101f266b216a246", size = 1855071, upload-time = "2025-04-23T18:31:04.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/d3/4ae42d33f5e3f50dd467761304be2fa0a9417fbf09735bc2cce003480f2a/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc46a01bf8d62f227d5ecee74178ffc448ff4e5197c756331f71efcc66dc980f", size = 1897823, upload-time = "2025-04-23T18:31:06.377Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f3/aa5976e8352b7695ff808599794b1fba2a9ae2ee954a3426855935799488/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a144d4f717285c6d9234a66778059f33a89096dfb9b39117663fd8413d582dcc", size = 1983792, upload-time = "2025-04-23T18:31:07.93Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7a/cda9b5a23c552037717f2b2a5257e9b2bfe45e687386df9591eff7b46d28/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73cf6373c21bc80b2e0dc88444f41ae60b2f070ed02095754eb5a01df12256de", size = 2136338, upload-time = "2025-04-23T18:31:09.283Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/b8f9ec8dd1417eb9da784e91e1667d58a2a4a7b7b34cf4af765ef663a7e5/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3dc625f4aa79713512d1976fe9f0bc99f706a9dee21dfd1810b4bbbf228d0e8a", size = 2730998, upload-time = "2025-04-23T18:31:11.7Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bc/cd720e078576bdb8255d5032c5d63ee5c0bf4b7173dd955185a1d658c456/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881b21b5549499972441da4758d662aeea93f1923f953e9cbaff14b8b9565aef", size = 2003200, upload-time = "2025-04-23T18:31:13.536Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/22/3602b895ee2cd29d11a2b349372446ae9727c32e78a94b3d588a40fdf187/pydantic_core-2.33.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bdc25f3681f7b78572699569514036afe3c243bc3059d3942624e936ec93450e", size = 2113890, upload-time = "2025-04-23T18:31:15.011Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e6/e3c5908c03cf00d629eb38393a98fccc38ee0ce8ecce32f69fc7d7b558a7/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fe5b32187cbc0c862ee201ad66c30cf218e5ed468ec8dc1cf49dec66e160cc4d", size = 2073359, upload-time = "2025-04-23T18:31:16.393Z" },
+    { url = "https://files.pythonhosted.org/packages/12/e7/6a36a07c59ebefc8777d1ffdaf5ae71b06b21952582e4b07eba88a421c79/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:bc7aee6f634a6f4a95676fcb5d6559a2c2a390330098dba5e5a5f28a2e4ada30", size = 2245883, upload-time = "2025-04-23T18:31:17.892Z" },
+    { url = "https://files.pythonhosted.org/packages/16/3f/59b3187aaa6cc0c1e6616e8045b284de2b6a87b027cce2ffcea073adf1d2/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:235f45e5dbcccf6bd99f9f472858849f73d11120d76ea8707115415f8e5ebebf", size = 2241074, upload-time = "2025-04-23T18:31:19.205Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ed/55532bb88f674d5d8f67ab121a2a13c385df382de2a1677f30ad385f7438/pydantic_core-2.33.2-cp311-cp311-win32.whl", hash = "sha256:6368900c2d3ef09b69cb0b913f9f8263b03786e5b2a387706c5afb66800efd51", size = 1910538, upload-time = "2025-04-23T18:31:20.541Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1b/25b7cccd4519c0b23c2dd636ad39d381abf113085ce4f7bec2b0dc755eb1/pydantic_core-2.33.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e063337ef9e9820c77acc768546325ebe04ee38b08703244c1309cccc4f1bab", size = 1952909, upload-time = "2025-04-23T18:31:22.371Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a9/d809358e49126438055884c4366a1f6227f0f84f635a9014e2deb9b9de54/pydantic_core-2.33.2-cp311-cp311-win_arm64.whl", hash = "sha256:6b99022f1d19bc32a4c2a0d544fc9a76e3be90f0b3f4af413f87d38749300e65", size = 1897786, upload-time = "2025-04-23T18:31:24.161Z" },
+    { url = "https://files.pythonhosted.org/packages/18/8a/2b41c97f554ec8c71f2a8a5f85cb56a8b0956addfe8b0efb5b3d77e8bdc3/pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc", size = 2009000, upload-time = "2025-04-23T18:31:25.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7", size = 1847996, upload-time = "2025-04-23T18:31:27.341Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/46/6dcdf084a523dbe0a0be59d054734b86a981726f221f4562aed313dbcb49/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025", size = 1880957, upload-time = "2025-04-23T18:31:28.956Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6b/1ec2c03837ac00886ba8160ce041ce4e325b41d06a034adbef11339ae422/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011", size = 1964199, upload-time = "2025-04-23T18:31:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/1d/6bf34d6adb9debd9136bd197ca72642203ce9aaaa85cfcbfcf20f9696e83/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f", size = 2120296, upload-time = "2025-04-23T18:31:32.514Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/94/2bd0aaf5a591e974b32a9f7123f16637776c304471a0ab33cf263cf5591a/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88", size = 2676109, upload-time = "2025-04-23T18:31:33.958Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1", size = 2002028, upload-time = "2025-04-23T18:31:39.095Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/d5/7bb781bf2748ce3d03af04d5c969fa1308880e1dca35a9bd94e1a96a922e/pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b", size = 2100044, upload-time = "2025-04-23T18:31:41.034Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/36/def5e53e1eb0ad896785702a5bbfd25eed546cdcf4087ad285021a90ed53/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1", size = 2058881, upload-time = "2025-04-23T18:31:42.757Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6c/57f8d70b2ee57fc3dc8b9610315949837fa8c11d86927b9bb044f8705419/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6", size = 2227034, upload-time = "2025-04-23T18:31:44.304Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b9/9c17f0396a82b3d5cbea4c24d742083422639e7bb1d5bf600e12cb176a13/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea", size = 2234187, upload-time = "2025-04-23T18:31:45.891Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/adf5734ffd52bf86d865093ad70b2ce543415e0e356f6cacabbc0d9ad910/pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290", size = 1892628, upload-time = "2025-04-23T18:31:47.819Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e4/5479fecb3606c1368d496a825d8411e126133c41224c1e7238be58b87d7e/pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2", size = 1955866, upload-time = "2025-04-23T18:31:49.635Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/24/8b11e8b3e2be9dd82df4b11408a67c61bb4dc4f8e11b5b0fc888b38118b5/pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab", size = 1888894, upload-time = "2025-04-23T18:31:51.609Z" },
+    { url = "https://files.pythonhosted.org/packages/46/8c/99040727b41f56616573a28771b1bfa08a3d3fe74d3d513f01251f79f172/pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f", size = 2015688, upload-time = "2025-04-23T18:31:53.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cc/5999d1eb705a6cefc31f0b4a90e9f7fc400539b1a1030529700cc1b51838/pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6", size = 1844808, upload-time = "2025-04-23T18:31:54.79Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/5e/a0a7b8885c98889a18b6e376f344da1ef323d270b44edf8174d6bce4d622/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef", size = 1885580, upload-time = "2025-04-23T18:31:57.393Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2a/953581f343c7d11a304581156618c3f592435523dd9d79865903272c256a/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a", size = 1973859, upload-time = "2025-04-23T18:31:59.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/55/f1a813904771c03a3f97f676c62cca0c0a4138654107c1b61f19c644868b/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916", size = 2120810, upload-time = "2025-04-23T18:32:00.78Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/c3/053389835a996e18853ba107a63caae0b9deb4a276c6b472931ea9ae6e48/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a", size = 2676498, upload-time = "2025-04-23T18:32:02.418Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/3c/f4abd740877a35abade05e437245b192f9d0ffb48bbbbd708df33d3cda37/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d", size = 2000611, upload-time = "2025-04-23T18:32:04.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a7/63ef2fed1837d1121a894d0ce88439fe3e3b3e48c7543b2a4479eb99c2bd/pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56", size = 2107924, upload-time = "2025-04-23T18:32:06.129Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/2551964ef045669801675f1cfc3b0d74147f4901c3ffa42be2ddb1f0efc4/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5", size = 2063196, upload-time = "2025-04-23T18:32:08.178Z" },
+    { url = "https://files.pythonhosted.org/packages/26/bd/d9602777e77fc6dbb0c7db9ad356e9a985825547dce5ad1d30ee04903918/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e", size = 2236389, upload-time = "2025-04-23T18:32:10.242Z" },
+    { url = "https://files.pythonhosted.org/packages/42/db/0e950daa7e2230423ab342ae918a794964b053bec24ba8af013fc7c94846/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162", size = 2239223, upload-time = "2025-04-23T18:32:12.382Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4d/4f937099c545a8a17eb52cb67fe0447fd9a373b348ccfa9a87f141eeb00f/pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849", size = 1900473, upload-time = "2025-04-23T18:32:14.034Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/75/4a0a9bac998d78d889def5e4ef2b065acba8cae8c93696906c3a91f310ca/pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9", size = 1955269, upload-time = "2025-04-23T18:32:15.783Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/86/1beda0576969592f1497b4ce8e7bc8cbdf614c352426271b1b10d5f0aa64/pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9", size = 1893921, upload-time = "2025-04-23T18:32:18.473Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162, upload-time = "2025-04-23T18:32:20.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560, upload-time = "2025-04-23T18:32:22.354Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777, upload-time = "2025-04-23T18:32:25.088Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/27/d4ae6487d73948d6f20dddcd94be4ea43e74349b56eba82e9bdee2d7494c/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:dd14041875d09cc0f9308e37a6f8b65f5585cf2598a53aa0123df8b129d481f8", size = 2025200, upload-time = "2025-04-23T18:33:14.199Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b8/b3cb95375f05d33801024079b9392a5ab45267a63400bf1866e7ce0f0de4/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d87c561733f66531dced0da6e864f44ebf89a8fba55f31407b00c2f7f9449593", size = 1859123, upload-time = "2025-04-23T18:33:16.555Z" },
+    { url = "https://files.pythonhosted.org/packages/05/bc/0d0b5adeda59a261cd30a1235a445bf55c7e46ae44aea28f7bd6ed46e091/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f82865531efd18d6e07a04a17331af02cb7a651583c418df8266f17a63c6612", size = 1892852, upload-time = "2025-04-23T18:33:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/11/d37bdebbda2e449cb3f519f6ce950927b56d62f0b84fd9cb9e372a26a3d5/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bfb5112df54209d820d7bf9317c7a6c9025ea52e49f46b6a2060104bba37de7", size = 2067484, upload-time = "2025-04-23T18:33:20.475Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/55/1f95f0a05ce72ecb02a8a8a1c3be0579bbc29b1d5ab68f1378b7bebc5057/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:64632ff9d614e5eecfb495796ad51b0ed98c453e447a76bcbeeb69615079fc7e", size = 2108896, upload-time = "2025-04-23T18:33:22.501Z" },
+    { url = "https://files.pythonhosted.org/packages/53/89/2b2de6c81fa131f423246a9109d7b2a375e83968ad0800d6e57d0574629b/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:f889f7a40498cc077332c7ab6b4608d296d852182211787d4f3ee377aaae66e8", size = 2069475, upload-time = "2025-04-23T18:33:24.528Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e9/1f7efbe20d0b2b10f6718944b5d8ece9152390904f29a78e68d4e7961159/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf", size = 2239013, upload-time = "2025-04-23T18:33:26.621Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/5309c905a93811524a49b4e031e9851a6b00ff0fb668794472ea7746b448/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb", size = 2238715, upload-time = "2025-04-23T18:33:28.656Z" },
+    { url = "https://files.pythonhosted.org/packages/32/56/8a7ca5d2cd2cda1d245d34b1c9a942920a718082ae8e54e5f3e5a58b7add/pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1", size = 2066757, upload-time = "2025-04-23T18:33:30.645Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/c5/dbbc27b814c71676593d1c3f718e6cd7d4f00652cefa24b75f7aa3efb25e/pydantic_settings-2.11.0.tar.gz", hash = "sha256:d0e87a1c7d33593beb7194adb8470fc426e95ba02af83a0f23474a04c9a08180", size = 188394, upload-time = "2025-09-24T14:19:11.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/d6/887a1ff844e64aa823fb4905978d882a633cfe295c32eacad582b78a7d8b/pydantic_settings-2.11.0-py3-none-any.whl", hash = "sha256:fe2cea3413b9530d10f3a5875adffb17ada5c1e1bab0b2885546d7310415207c", size = 48608, upload-time = "2025-09-24T14:19:10.015Z" },
+]
+
+[package.optional-dependencies]
+yaml = [
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -712,6 +824,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
 ]
 
 [[package]]
@@ -941,6 +1062,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements persistent Pydantic-based configuration with user/repo separation for security, environment variable precedence, and full TUI compliance. All 10 tasks complete with comprehensive edge case testing, user documentation, and Windows CI integration.

**User Story**: As a developer, I want persistent configuration with user and repo separation so that my API keys stay secure in my home directory while team settings are shared in the repo, with my existing OPENAI_API_KEY automatically recognized.

## Implementation Highlights

### Security & Separation
- **User config** (`~/.gitctx/config.yml`) - API keys only, 0600 permissions, never committed
- **Repo config** (`.gitctx/config.yml`) - Team settings only, 0644 permissions, safe to commit
- Automatic routing by key pattern: `api_keys.*` → user, else → repo
- Impossible to store API keys in repo config (enforced by Pydantic models)

### Environment Variable Precedence
- **User config (API keys)**: `OPENAI_API_KEY` > `~/.gitctx/config.yml`
- **Repo config (team settings)**: `GITCTX_SEARCH__LIMIT` > `.gitctx/config.yml`
- Type-safe validation with Pydantic
- Auto-masking of secrets using SecretStr

### TUI Compliance (Progressive Disclosure)
- **Default mode (terse)**: `config init` → "Initialized .gitctx/", `config get` → value only
- **Verbose mode**: `config get -v` → shows key and source, `config list -v` → shows all sources
- **Quiet mode**: `--quiet` suppresses all output for scripting
- **Platform symbols**: ✓/✗/⚠️/💡 on modern terminals, [OK]/[X]/[!]/[i] on Windows cmd.exe
- **First-run tips**: Show tip box once per command, then hide forever
- **Standard exit codes**: 0=success, 1=error, 2=validation, 6=permission

### Commands Implemented
- `gitctx config init` - Creates `.gitctx/` structure with config.yml and .gitignore
- `gitctx config set <key> <value>` - Auto-routes to user or repo config
- `gitctx config get <key>` - Shows value (or key + source with --verbose)
- `gitctx config list` - Shows all config (with sources in --verbose)

## Test Coverage

**Coverage: 94.59%** (exceeds 85% target by +9.59%)

- **194 tests total** (192 passing, 2 skipped on non-Windows)
- **19 BDD scenarios** - All passing
- **9 files at 100% coverage**
- Comprehensive edge case testing (Unicode, corruption, permissions)
- Windows-specific tests for ACLs, paths, symbols
- Zero filesystem pollution from tests

## Tasks Completed (10/10)

All tasks complete with 7.75 actual hours vs 7.25 estimated:

- ✅ [TASK-0001.1.2.1](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.1.md) - Write BDD Scenarios for User/Repo Config Separation (1.0h)
- ✅ [TASK-0001.1.2.2](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.2.md) - Implement User and Repo Config with Pydantic Settings (1.0h)
- ✅ [TASK-0001.1.2.3](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.3.md) - Integrate with CLI Commands and Add Config Init (2.5h)
- ✅ [TASK-0001.1.2.4](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.4.md) - Security Hardening - Permission Checks (0.5h)
- ✅ [TASK-0001.1.2.5](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.5.md) - Code Documentation Improvements (0.25h)
- ✅ [TASK-0001.1.2.6](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.6.md) - User-Friendly Validation Errors (0.5h)
- ✅ [TASK-0001.1.2.7](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.7.md) - Fix get_source() Complexity Violation (0.25h)
- ✅ [TASK-0001.1.2.8](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.8.md) - Add Essential Edge Case Tests (0.25h)
- ✅ [TASK-0001.1.2.9](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.9.md) - Create Configuration User Documentation (1.0h)
- ✅ [TASK-0001.1.2.10](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/docs/tickets/INIT-0001/EPIC-0001.1/STORY-0001.1.2/TASK-0001.1.2.10.md) - Add Windows CI Integration Tests (0.5h)

## Key Files

### New Core Files
- [src/gitctx/cli/tips.py](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/src/gitctx/cli/tips.py) - First-run tips system
- [src/gitctx/core/config.py](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/src/gitctx/core/config.py) - GitCtxSettings aggregator
- [src/gitctx/core/user_config.py](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/src/gitctx/core/user_config.py) - User config (API keys)
- [src/gitctx/core/repo_config.py](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/src/gitctx/core/repo_config.py) - Repo config (team settings)

### Modified Files
- [src/gitctx/cli/config.py](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/src/gitctx/cli/config.py) - Complete rewrite with Pydantic integration
- [pyproject.toml](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/pyproject.toml) - Added pydantic dependencies, pytest --color=yes
- [.gitignore](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/.gitignore) - Added coverage.json

### Test Files
- [tests/conftest.py](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/tests/conftest.py) - Added isolated_cli_runner fixture
- [tests/e2e/features/cli.feature](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/tests/e2e/features/cli.feature) - 19 new BDD scenarios
- [tests/unit/cli/test_config.py](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/tests/unit/cli/test_config.py) - Comprehensive config CLI tests
- [tests/unit/core/test_config.py](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/tests/unit/core/test_config.py) - GitCtxSettings tests
- [tests/unit/core/test_user_config.py](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/tests/unit/core/test_user_config.py) - User config + Windows tests
- [tests/unit/core/test_repo_config.py](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/tests/unit/core/test_repo_config.py) - Repo config tests

### Documentation
- [docs/configuration.md](https://github.com/gitctx-ai/gitctx/blob/STORY-0001.1.2/docs/configuration.md) - Comprehensive user guide with examples

## Quality Gates

- ✅ All 194 tests passing (192 pass, 2 skipped on non-Windows)
- ✅ Ruff check passed
- ✅ Ruff format passed  
- ✅ Mypy type checking passed
- ✅ Coverage 94.59% (target: 85%, +9.59%)
- ✅ Zero filesystem pollution from tests
- ✅ Cross-platform compatibility (Windows/macOS/Linux)
- ✅ All complexity thresholds met (≤10, get_source=11 addressed)
- ✅ Windows CI integration complete with ACL and path tests

## Acceptance Criteria

All 47 acceptance criteria met:
- ✅ Pydantic Settings with type-safe validation
- ✅ User/repo config separation with proper permissions
- ✅ Environment variable precedence (OPENAI_API_KEY, GITCTX_*)
- ✅ TUI progressive disclosure (terse/verbose/quiet modes)
- ✅ Platform-aware symbols (Unicode vs ASCII)
- ✅ First-run tips system
- ✅ Standard exit codes (0/1/2/6)
- ✅ Security: API keys never in repo config
- ✅ Cross-platform compatibility verified
- ✅ Edge cases tested (Unicode, corruption, auto-create)
- ✅ Comprehensive user documentation
- ✅ Windows-specific tests passing in CI

## Story Evolution

**Initial Scope**: Tasks 1-3 for core config (2.0 hours)

**Additions from PR Review**: 
- TASK-4,5,6: Security hardening, docs, UX (1.25h)
- TASK-7,8,9,10: Complexity fix, edge cases, user docs, Windows CI (2.0h)

**Overengineering Eliminated**:
- Config caching removed (CLI process model makes it unnecessary)
- Large refactor reduced to targeted complexity fix
- Net reduction: 3.25 hours of unnecessary work avoided

**Final**: 10 tasks, 7.75 actual hours, production-ready quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)